### PR TITLE
[TASK] Make sure to exclude the public folder when packaging

### DIFF
--- a/conf/ExcludeFromPackaging.php
+++ b/conf/ExcludeFromPackaging.php
@@ -19,6 +19,7 @@ return [
         '.idea',
         'bin',
         'build',
+        'public',
         'tailor-version-upload',
         'tests',
         'vendor',


### PR DESCRIPTION
When you did a composer install within your extension folder, the public folder also contained TYPO3 core extensions. As those are not needed for packaging, it is best to exclude this folder.