### PR TITLE
[BUGFIX] Fix typo in php file extension in the exclude list

### DIFF
--- a/conf/ExcludeFromPackaging.php
+++ b/conf/ExcludeFromPackaging.php
@@ -48,7 +48,7 @@ return [
         'package-lock.json',
         'package.json',
         'php_cs',
-        'php_cs.pp',
+        'php_cs.php',
         'phpcs.xml',
         'phpcs.xml.dist',
         'phplint.yml',


### PR DESCRIPTION
The file extension is `.php`, not `.pp`.