### PR TITLE
[BUGFIX] info() not available in symfony/console:^4.4

### DIFF
--- a/src/Command/Extension/SetExtensionVersionCommand.php
+++ b/src/Command/Extension/SetExtensionVersionCommand.php
@@ -82,7 +82,7 @@ class SetExtensionVersionCommand extends Command
 
         $documentationSettingsFile = rtrim($path, '/') . '/Documentation/Settings.cfg';
         if (!file_exists($documentationSettingsFile)) {
-            $io->info(
+            $io->note(
                 'Documentation version update is enabled but was not performed because the file '
                 . $documentationSettingsFile . ' does not exist. To disable this operation use the \'--no-docs\' '
                 . 'option or set the \'TYPO3_DISABLE_DOCS_VERSION_UPDATE\' environment variable.'


### PR DESCRIPTION
SymfonyStyle->info() has been added somewhere in symfony/console
v5. Use ->note() instead to be compatible with ^4.4 as defined
in composer.json to avoid a fatal.