### PR TITLE
[TASK] Stop packaging development tools and the PHIVE configuration

### DIFF
--- a/conf/ExcludeFromPackaging.php
+++ b/conf/ExcludeFromPackaging.php
@@ -22,6 +22,7 @@ return [
         'public',
         'tailor-version-upload',
         'tests',
+        'tools',
         'vendor',
     ],
     'files' => [
@@ -47,6 +48,7 @@ return [
         'gitreview',
         'package-lock.json',
         'package.json',
+        'phive.xml',
         'php_cs',
         'php_cs.php',
         'phpcs.xml',


### PR DESCRIPTION
To avoid dependency hell for development dependencies, many tools
are available to be installed as PHARS using the PHIVE tool.

As these are development-only tools, the PHIVE configuration file
and the `tools/` directory (which by convention is used for the
PHIVE-installed PHARs) should be excluded from packaging by default.