### PR TITLE
[BUGFIX] fix Github Workflow syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,8 @@ look at the [tailor_ext][tailor-ext] example extension.
 name: publish
 on:
   push:
-    tag:
+    tags:
+      - *
 jobs:
   publish:
     name: Publish new version to TER

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ name: publish
 on:
   push:
     tags:
-      - *
+      - '*'
 jobs:
   publish:
     name: Publish new version to TER


### PR DESCRIPTION
According to
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
it should be `tags`, not `tag`.