### PR TITLE
[FEATURE] Also test for compatibility with PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
+        php: ["7.2", "7.3", "7.4", "8.0", "8.1"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,9 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest --optimize-autoloader
 
-      - name: Run Tests
-        run: |
-          composer tests:unit
-          composer cs
+      - name: Run cgl
+        if: ${{ matrix.php != '8.1' }}
+        run: composer cs
 
+      - name: Run unit tests
+        run: composer tests:unit

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /.php_cs.cache
+/.php-cs-fixer.cache
 /.DS_Store
 /vendor
 /.env

--- a/README.md
+++ b/README.md
@@ -453,6 +453,13 @@ ${GITHUB_REF#refs/tags/v}
 $(git tag -n10 -l v${{ steps.get-version.outputs.version }} | sed "s/^v[0-9.]*[ ]*//g")
 ```
 
+#### GitHub actions from TYPO3 community
+
+Additionally, to further simplify your workflow, you can also use the
+[typo3-uploader-ter][typo3-uploader-ter] GitHub action from TYPO3 community
+member Tomas Norre. For more information about the usage, please refer to the
+corresponding [README][typo3-uploader-ter-readme].
+
 ### GitLab pipeline
 
 The job will only be executed when pushing a new tag.
@@ -531,3 +538,5 @@ MIT License, see LICENSE
 [rest-api]: https://extensions.typo3.org/faq/rest-api/
 [ter]: https://extensions.typo3.org
 [tailor-ext]: https://github.com/o-ba/tailor_ext
+[typo3-uploader-ter]: https://github.com/tomasnorre/typo3-upload-ter
+[typo3-uploader-ter-readme]: https://github.com/tomasnorre/typo3-upload-ter/blob/main/README.md

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ access token. You can create such token either on
 [https://extensions.typo3.org/][ter] after you've logged in, or
 directly using Tailor.
 
-**Note:** To create an access token with Tailor, you have to add your
-TYPO3.org credentials (see below). Even if it is possible to execute
-all commands using the TYPO3.org credentials for authentication, it
-is highly discouraged. That's why we have built token based
-authentication for the [TER][ter].
+**Note:** To create, refresh or revoke an access token with Tailor,
+you have to add your TYPO3.org credentials (see below). Even if it
+is possible to execute all commands using the TYPO3.org credentials
+for authentication, it is highly discouraged. That's why we have
+built token based authentication for the [TER][ter].
 
 Provide your credentials by either creating a `.env` file in the
 project root folder or setting environment variables through your

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
             "@php vendor/bin/phpunit --testsuite Unit"
         ],
         "cs": [
-            "@php vendor/bin/php-cs-fixer fix --dry-run --diff --diff-format=udiff --config=vendor/typo3/coding-standards/templates/extension_php_cs.dist src/ tests/"
+            "@php vendor/bin/php-cs-fixer fix --dry-run --diff --config=vendor/typo3/coding-standards/templates/extension_php-cs-fixer.dist.php src/ tests/"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "typo3/coding-standards": ">=0.2.0 <1.0.0"
+        "typo3/coding-standards": "^0.4.0"
     },
     "bin": [
         "bin/tailor"

--- a/src/Command/Extension/UploadExtensionVersionCommand.php
+++ b/src/Command/Extension/UploadExtensionVersionCommand.php
@@ -121,7 +121,7 @@ class UploadExtensionVersionCommand extends AbstractClientRequestCommand
         return new FormDataPart([
             'description' => (string)$options['comment'],
             'gplCompliant' => '1',
-            'file' => DataPart::fromPath($versionService->getVersionFilePath())
+            'file' => DataPart::fromPath($versionService->getVersionFilePath()),
         ]);
     }
 

--- a/src/Formatter/ConsoleFormatter.php
+++ b/src/Formatter/ConsoleFormatter.php
@@ -117,7 +117,7 @@ class ConsoleFormatter
             new OutputPart(
                 [
                     ['Extension Key', 'Title', 'Latest Version', 'Last Updated on', 'Composer Name'],
-                    $extensions
+                    $extensions,
                 ],
                 OutputPart::OUTPUT_TABLE
             )

--- a/src/HttpClientFactory.php
+++ b/src/HttpClientFactory.php
@@ -41,7 +41,7 @@ final class HttpClientFactory
                 'User-Agent' => 'Tailor - Your TYPO3 Extension Helper',
             ], $requestConfiguration->getHeaders()),
             // REST API does not perform redirects
-            'max_redirects' => 0
+            'max_redirects' => 0,
         ];
         if ($requestConfiguration->getQuery() !== []) {
             $options['query'] = $requestConfiguration->getQuery();

--- a/tests/Unit/Fixtures/EmConf/emconf_invalid.php
+++ b/tests/Unit/Fixtures/EmConf/emconf_invalid.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'YES' => true
+    'YES' => true,
 ];

--- a/tests/Unit/Fixtures/EmConf/emconf_no_structure.php
+++ b/tests/Unit/Fixtures/EmConf/emconf_no_structure.php
@@ -1,5 +1,5 @@
 <?php
 
 $EM_CONF = [
-    'nothing' => 'YES'
+    'nothing' => 'YES',
 ];

--- a/tests/Unit/Fixtures/EmConf/emconf_no_version.php
+++ b/tests/Unit/Fixtures/EmConf/emconf_no_version.php
@@ -1,5 +1,5 @@
 <?php
 
 $EM_CONF = [
-    'nothing' => 'YES'
+    'nothing' => 'YES',
 ];

--- a/tests/Unit/Fixtures/EmConf/emconf_valid.php
+++ b/tests/Unit/Fixtures/EmConf/emconf_valid.php
@@ -14,6 +14,6 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '10.0.0-11.99.99',
-        ]
-    ]
+        ],
+    ],
 ];

--- a/tests/Unit/Fixtures/EmConf/emconf_valid_string_array_key.php
+++ b/tests/Unit/Fixtures/EmConf/emconf_valid_string_array_key.php
@@ -14,6 +14,6 @@ $EM_CONF['my_extension'] = [
     'constraints' => [
         'depends' => [
             'typo3' => '10.0.0-11.99.99',
-        ]
-    ]
+        ],
+    ],
 ];

--- a/tests/Unit/Fixtures/ExcludeFromPackaging/config_invalid.php
+++ b/tests/Unit/Fixtures/ExcludeFromPackaging/config_invalid.php
@@ -2,6 +2,6 @@
 
 return [
     'folders' => [
-        'dummy'
-    ]
+        'dummy',
+    ],
 ];

--- a/tests/Unit/Fixtures/ExcludeFromPackaging/config_valid.php
+++ b/tests/Unit/Fixtures/ExcludeFromPackaging/config_valid.php
@@ -2,9 +2,9 @@
 
 return [
     'directories' => [
-        'dummy'
+        'dummy',
     ],
     'files' => [
         'dummy',
-    ]
+    ],
 ];

--- a/tests/Unit/Formatter/ConsoleFormatterTest.php
+++ b/tests/Unit/Formatter/ConsoleFormatterTest.php
@@ -53,19 +53,19 @@ class ConsoleFormatterTest extends TestCase
         yield 'No output' => [
             [
                 'some' => [
-                    'dummy' => 'data'
-                ]
+                    'dummy' => 'data',
+                ],
             ],
             [],
             [],
-            ConsoleFormatter::FORMAT_NONE
+            ConsoleFormatter::FORMAT_NONE,
         ];
         yield 'Simple key/values array' => [
             [
                 'dummy' => 'data',
                 'noKey',
                 'notKeyValue' => [
-                    'foo' => 'bar'
+                    'foo' => 'bar',
                 ],
                 'some_Key' => 'otherData',
             ],
@@ -75,7 +75,7 @@ class ConsoleFormatterTest extends TestCase
                 ['<info>Some Key</info>: otherData'],
             ],
             [],
-            ConsoleFormatter::FORMAT_KEY_VALUE
+            ConsoleFormatter::FORMAT_KEY_VALUE,
         ];
         yield 'Extension details list' => [
             [
@@ -87,12 +87,12 @@ class ConsoleFormatterTest extends TestCase
                     'paypal_url' => '',
                     'tags' => [
                         [
-                            'title' => 'sometag'
+                            'title' => 'sometag',
                         ],
                         [
-                            'title' => 'anothertag'
-                        ]
-                    ]
+                            'title' => 'anothertag',
+                        ],
+                    ],
                 ],
                 'current_version' => [
                     'title' => 'foobar',
@@ -101,13 +101,13 @@ class ConsoleFormatterTest extends TestCase
                     'state' => 'stable',
                     'category' => 'be',
                     'typo3_versions' => [
-                        9, 10
+                        9, 10,
                     ],
                     'dependencies' => [
                         'typo3' => '10.0.0 - 10.99.99',
                     ],
                     'conflicts' => [
-                        'templavoila' => '*'
+                        'templavoila' => '*',
                     ],
                     'downloads' => 1234,
                     'upload_date' => 1606400890,
@@ -115,14 +115,14 @@ class ConsoleFormatterTest extends TestCase
                     'download' => [
                         'composer' => 'composer req vendor/some_ext',
                         'zip' => 'https://extensions.typo3.org/extension/download/some_ext/1.0.0/zip',
-                        't3x' => 'https://extensions.typo3.org/extension/download/some_ext/1.0.0/t3x'
+                        't3x' => 'https://extensions.typo3.org/extension/download/some_ext/1.0.0/t3x',
                     ],
                     'author' => [
                         'name' => 'John Doe',
                         'email' => 'some-mail@example.com',
-                        'company' => 'ACME Inc'
-                    ]
-                ]
+                        'company' => 'ACME Inc',
+                    ],
+                ],
             ],
             [
                 ['<info>Key</info>: some_ext'],
@@ -156,10 +156,10 @@ class ConsoleFormatterTest extends TestCase
                 [PHP_EOL . 'Author'],
                 ['<info>Name</info>: John Doe'],
                 ['<info>Email</info>: some-mail@example.com'],
-                ['<info>Company</info>: ACME Inc']
+                ['<info>Company</info>: ACME Inc'],
             ],
             [],
-            ConsoleFormatter::FORMAT_DETAIL
+            ConsoleFormatter::FORMAT_DETAIL,
         ];
         yield 'Details with empty array' => [
             [
@@ -168,19 +168,19 @@ class ConsoleFormatterTest extends TestCase
                 'version_count' => 2,
                 'meta' => [
                     'composer_name' => 'vendor/some_ext',
-                    'tags' => []
+                    'tags' => [],
                 ],
-                'current_version' => []
+                'current_version' => [],
             ],
             [
                 ['<info>Key</info>: some_ext'],
                 ['<info>Downloads</info>: 60'],
                 ['<info>Version count</info>: 2'],
                 [PHP_EOL . 'Meta'],
-                ['<info>Composer name</info>: vendor/some_ext']
+                ['<info>Composer name</info>: vendor/some_ext'],
             ],
             [],
-            ConsoleFormatter::FORMAT_DETAIL
+            ConsoleFormatter::FORMAT_DETAIL,
         ];
         yield 'Find extensions result' => [
             [
@@ -188,40 +188,40 @@ class ConsoleFormatterTest extends TestCase
                 'page' => 1,
                 'per_page' => 2,
                 'filter' => [
-                    'username' => 'some_user'
+                    'username' => 'some_user',
                 ],
                 'extensions' => [
                     [
                         'key' => 'some_ext',
                         'meta' => [
-                            'composer_name' => 'vendor/some_ext'
+                            'composer_name' => 'vendor/some_ext',
                         ],
                         'current_version' => [
                             'title' => 'foobar',
                             'number' => '1.0.0',
-                            'upload_date' => 1605785659
-                        ]
+                            'upload_date' => 1605785659,
+                        ],
                     ],
                     [
-                        'key' => 'another_ext'
-                    ]
-                ]
+                        'key' => 'another_ext',
+                    ],
+                ],
             ],
             [
                 [
                     ['Extension Key', 'Title', 'Latest Version', 'Last Updated on', 'Composer Name'],
                     [
                         'another_ext' => ['another_ext', '-', '-', '-', '-'],
-                        'some_ext' => ['some_ext', 'foobar', '1.0.0', '19.11.2020', 'vendor/some_ext']
-                    ]
+                        'some_ext' => ['some_ext', 'foobar', '1.0.0', '19.11.2020', 'vendor/some_ext'],
+                    ],
                 ],
-                ['Page: 1, Per page: 2, Filter: some_user (Author)']
+                ['Page: 1, Per page: 2, Filter: some_user (Author)'],
             ],
             [
                 OutputPart::OUTPUT_TABLE,
-                OutputPart::OUTPUT_WRITE_LINE
+                OutputPart::OUTPUT_WRITE_LINE,
             ],
-            ConsoleFormatter::FORMAT_TABLE
+            ConsoleFormatter::FORMAT_TABLE,
         ];
     }
 }

--- a/tests/Unit/Validation/VersionValidatorTest.php
+++ b/tests/Unit/Validation/VersionValidatorTest.php
@@ -38,35 +38,35 @@ class VersionValidatorTest extends TestCase
     {
         yield 'Wrong format' => [
             'v1',
-            false
+            false,
         ];
         yield 'Wrong delimiter' => [
             '1-0-0',
-            false
+            false,
         ];
         yield 'Missing patch version' => [
             '1.0',
-            false
+            false,
         ];
         yield 'Patch version to high' => [
             '1.0.1000',
-            false
+            false,
         ];
         yield 'Patch version to low' => [
             '1.0.-12',
-            false
+            false,
         ];
         yield 'Not numeric' => [
             '0.2.0-alpha',
-            false
+            false,
         ];
         yield 'Valid version' => [
             '1.0.0',
-            true
+            true,
         ];
         yield 'Valid version 2' => [
             '10.4.999',
-            true
+            true,
         ];
     }
 }


### PR DESCRIPTION
Also quote the PHP version numbers in the GitHub Actions configuration
file in order to keep "8.0" to getting autoconverted into the integer 8.