### PR TITLE
[TASK] Do not package the PHPStorm meta file

### DIFF
--- a/conf/ExcludeFromPackaging.php
+++ b/conf/ExcludeFromPackaging.php
@@ -60,6 +60,7 @@ return [
         'phpstan-baseline.neon',
         'phpstan.neon',
         'phpstan.neon.dist',
+        'phpstorm.meta.php',
         'phpunit.xml',
         'phpunit.xml.dist',
         'prettierrc.json',


### PR DESCRIPTION
This file also is a development-only file that should not be packaged.