### PR TITLE
[FEATURE] Introduce command to create local extension artefact

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ versions to the [extension repository][ter].
   - [Register a new extension key](#register-a-new-extension-key)
   - [Update the version in your extension files](#update-the-version-in-your-extension-files)
   - [Publish a new version of an extension to TER](#publish-a-new-version-of-an-extension-to-ter)
+  - [Create a local artefact of an extension](#create-a-local-artefact-of-an-extension)
   - [Update extension meta information](#update-extension-meta-information)
   - [Transfer ownership of an extension to another user](#transfer-ownership-of-an-extension-to-another-user)
   - [Delete / abandon an extension](#delete--abandon-an-extension)
@@ -235,6 +236,59 @@ configuration file to the environment variable
 an upload comment to be set. This can be achieved using the
 `--comment` option. If not set, Tailor will automatically use
 `Updated extension to <version>` as comment.
+
+### Create a local artefact of an extension
+
+You can generate a local artefact of your extension using the
+`create-artefact` command. This will generate a zip archive
+ready to be uploaded to TER (which is not covered by this
+command, have a look at the [`ter:publish`](#publish-a-new-version-of-an-extension-to-ter)
+command instead).
+
+Provide the version number and extension key as arguments
+followed by the path to the extension directory or an artefact
+(a zipped version of your extension). The latter can be either
+local or a remote file.
+
+Using `--path`:
+
+```bash
+./vendor/bin/tailor create-artefact 1.2.0 my_extension --path=/path/to/my_extension
+```
+
+Using a local `--artefact`:
+
+```bash
+./vendor/bin/tailor create-artefact 1.2.0 my_extension --artefact=/path/to/any-zip-file/my_extension.zip
+```
+
+Using a remote `--artefact`:
+
+```bash
+./vendor/bin/tailor create-artefact 1.2.0 my_extension --artefact=https://github.com/my-name/my_extension/archive/1.2.0.zip
+```
+
+Using the root directory:
+
+```bash
+./vendor/bin/tailor create-artefact 1.2.0 my_extension
+```
+
+If the extension key is defined as environment variable or
+in your `composer.json`, it can also be skipped. So using the
+current root directory the whole command simplifies to:
+
+```bash
+./vendor/bin/tailor create-artefact 1.2.0
+```
+
+**Important**: A couple of directories and files are excluded
+from packaging by default. You can find the configuration in
+`conf/ExcludeFromPackaging.php`. If you like, you can also
+use a custom configuration. Just add the path to your custom
+configuration file to the environment variable
+`TYPO3_EXCLUDE_FROM_PACKAGING`. This file must return an
+`array` with the keys `directories` and `files` on root level.
 
 ### Update extension meta information
 
@@ -559,21 +613,22 @@ The variable `CI_COMMIT_TAG` is set by GitLab automatically.
 
 ## Overview of all available commands
 
-| Commands              | Arguments                         | Options                                                                                               | Description                                     |
-| --------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| ``set-version``       | ``version``                       | ``--path``<br/>``--no-docs``                                                                          | Update the version in extension files           |
-| ``ter:delete``        | ``extensionkey``                  |                                                                                                       | Delete an extension.                            |
-| ``ter:details``       | ``extensionkey``                  |                                                                                                       | Fetch details about an extension.               |
-| ``ter:find``          |                                   | ``--page``<br/>``--per-page``<br/>``--author``<br/>``--typo3-version``                                | Fetch a list of extensions from TER.            |
-| ``ter:publish``       | ``version``<br/>``extensionkey``  | ``--path``<br/>``--artefact``<br/>``--comment``                                                       | Publishes a new version of an extension to TER. |
-| ``ter:register``      | ``extensionkey``                  |                                                                                                       | Register a new extension key in TER.            |
-| ``ter:token:create``  |                                   | ``--name``<br/>``--expires``<br/>``--scope``<br/>``--extensions``                                     | Request an access token for the TER.            |
-| ``ter:token:refresh`` | ``token``                         |                                                                                                       | Refresh an access token for the TER.            |
-| ``ter:token:revoke``  | ``token``                         |                                                                                                       | Revoke an access token for the TER.             |
-| ``ter:transfer``      | ``username``<br/>``extensionkey`` |                                                                                                       | Transfer ownership of an extension key.         |
-| ``ter:update``        | ``extensionkey``                  | ``--composer``<br/>``--issues``<br/>``--repository``<br/>``--manual``<br/>``--paypal``<br/>``--tags`` | Update extension meta information.              |
-| ``ter:version``       | ``version``<br/>``extensionkey``  |                                                                                                       | Fetch details about an extension version.       |
-| ``ter:versions``      | ``extensionkey``                  |                                                                                                       | Fetch details for all versions of an extension. |
+| Commands              | Arguments                         | Options                                                                                               | Description                                            |
+|-----------------------|-----------------------------------|-------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| ``set-version``       | ``version``                       | ``--path``<br/>``--no-docs``                                                                          | Update the version in extension files                  |
+| ``ter:delete``        | ``extensionkey``                  |                                                                                                       | Delete an extension.                                   |
+| ``ter:details``       | ``extensionkey``                  |                                                                                                       | Fetch details about an extension.                      |
+| ``ter:find``          |                                   | ``--page``<br/>``--per-page``<br/>``--author``<br/>``--typo3-version``                                | Fetch a list of extensions from TER.                   |
+| ``ter:publish``       | ``version``<br/>``extensionkey``  | ``--path``<br/>``--artefact``<br/>``--comment``                                                       | Publishes a new version of an extension to TER.        |
+| ``create-artefact``   | ``version``<br/>``extensionkey``  | ``--path``<br/>``--artefact``                                                                         | Create an artefact file (zip archive) of an extension. |
+| ``ter:register``      | ``extensionkey``                  |                                                                                                       | Register a new extension key in TER.                   |
+| ``ter:token:create``  |                                   | ``--name``<br/>``--expires``<br/>``--scope``<br/>``--extensions``                                     | Request an access token for the TER.                   |
+| ``ter:token:refresh`` | ``token``                         |                                                                                                       | Refresh an access token for the TER.                   |
+| ``ter:token:revoke``  | ``token``                         |                                                                                                       | Revoke an access token for the TER.                    |
+| ``ter:transfer``      | ``username``<br/>``extensionkey`` |                                                                                                       | Transfer ownership of an extension key.                |
+| ``ter:update``        | ``extensionkey``                  | ``--composer``<br/>``--issues``<br/>``--repository``<br/>``--manual``<br/>``--paypal``<br/>``--tags`` | Update extension meta information.                     |
+| ``ter:version``       | ``version``<br/>``extensionkey``  |                                                                                                       | Fetch details about an extension version.              |
+| ``ter:versions``      | ``extensionkey``                  |                                                                                                       | Fetch details for all versions of an extension.        |
 
 ### General options for all commands
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ versions to the [extension repository][ter].
 - [Publish a new version using your CI](#publish-a-new-version-using-your-ci)
   - [Github actions workflow](#github-actions-workflow)
   - [GitLab pipeline](#gitlab-pipeline)
+- [Exclude paths from packaging](#exclude-paths-from-packaging)
 - [Overview of all available commands](#overview-of-all-available-commands)
   - [General options for all commands](#general-options-for-all-commands)
 - [Author & License](#author--license)
@@ -39,11 +40,12 @@ access token. You can create such token either on
 [https://extensions.typo3.org/][ter] after you've logged in, or
 directly using Tailor.
 
-**Note:** To create, refresh or revoke an access token with Tailor,
-you have to add your TYPO3.org credentials (see below). Even if it
-is possible to execute all commands using the TYPO3.org credentials
-for authentication, it is highly discouraged. That's why we have
-built token based authentication for the [TER][ter].
+> [!IMPORTANT]
+> To create, refresh or revoke an access token with Tailor,
+> you have to add your TYPO3.org credentials (see below). Even if it
+> is possible to execute all commands using the TYPO3.org credentials
+> for authentication, it is highly discouraged. That's why we have
+> built token based authentication for the [TER][ter].
 
 Provide your credentials by either creating a `.env` file in the
 project root folder or setting environment variables through your
@@ -55,12 +57,14 @@ TYPO3_API_USERNAME=<your-t3o-username>
 TYPO3_API_PASSWORD=<your-t3o-password>
 ```
 
-**Note**: For an overview of all available environment variables,
-have a look at the `.env.dist` file.
+> [!NOTE]
+> For an overview of all available environment variables,
+> have a look at the `.env.dist` file.
 
-**Note**: You can also add environment variables directly on
-executing a command. This overrides any variable, defined in
-the `.env` file.
+> [!TIP]
+> You can also add environment variables directly on
+> executing a command. This overrides any variable, defined in
+> the `.env` file.
 
 Example:
 
@@ -99,9 +103,10 @@ either as environment variable or in your `composer.json`, you
 can still run all commands for different extensions by adding
 the desired extension key as argument to the command.
 
-**Note:** If no extension key is defined, neither as an argument,
-as environment variable, nor in your `composer.json`, commands
-which require an extension key to be set, will throw an exception.
+> [!NOTE]
+> If no extension key is defined, neither as an argument,
+> as environment variable, nor in your `composer.json`, commands
+> which require an extension key to be set, will throw an exception.
 
 ### Manage your personal access token
 
@@ -176,13 +181,15 @@ information in it. You can disable this feature by either
 using `--no-docs` or by setting the environment variable
 `TYPO3_DISABLE_DOCS_VERSION_UPDATE=1`.
 
-**Note**: It's also possible to use the `--path` option to
-specify the location of your extension. If not given, your
-current working directory is search for the `ext_emconf.php`
-file.
+> [!TIP]
+> It's also possible to use the `--path` option to
+> specify the location of your extension. If not given, your
+> current working directory is search for the `ext_emconf.php`
+> file.
 
-**Note**: The version will only be updated if already present
-in your `ext_emconf.php`. It won't be added by this command.
+> [!NOTE]
+> The version will only be updated if already present
+> in your `ext_emconf.php`. It won't be added by this command.
 
 ### Publish a new version of an extension to TER
 
@@ -224,18 +231,17 @@ current root directory the whole command simplifies to:
 ./vendor/bin/tailor ter:publish 1.2.0
 ```
 
-**Important**: A couple of directories and files are excluded
-from packaging by default. You can find the configuration in
-`conf/ExcludeFromPackaging.php`. If you like, you can also
-use a custom configuration. Just add the path to your custom
-configuration file to the environment variable
-`TYPO3_EXCLUDE_FROM_PACKAGING`. This file must return an
-`array` with the keys `directories` and `files` on root level.
+> [!IMPORTANT]
+> A couple of directories and files are excluded from packaging
+> by default. Read more about
+> [excluding paths from packaging](#exclude-paths-from-packaging)
+> below.
 
-**Note**: The REST API, just like the the [TER][ter], requires
-an upload comment to be set. This can be achieved using the
-`--comment` option. If not set, Tailor will automatically use
-`Updated extension to <version>` as comment.
+> [!NOTE]
+> The REST API, just like the the [TER][ter], requires
+> an upload comment to be set. This can be achieved using the
+> `--comment` option. If not set, Tailor will automatically use
+> `Updated extension to <version>` as comment.
 
 ### Create a local artefact of an extension
 
@@ -282,13 +288,11 @@ current root directory the whole command simplifies to:
 ./vendor/bin/tailor create-artefact 1.2.0
 ```
 
-**Important**: A couple of directories and files are excluded
-from packaging by default. You can find the configuration in
-`conf/ExcludeFromPackaging.php`. If you like, you can also
-use a custom configuration. Just add the path to your custom
-configuration file to the environment variable
-`TYPO3_EXCLUDE_FROM_PACKAGING`. This file must return an
-`array` with the keys `directories` and `files` on root level.
+> [!IMPORTANT]
+> A couple of directories and files are excluded from packaging
+> by default. Read more about
+> [excluding paths from packaging](#exclude-paths-from-packaging)
+> below.
 
 ### Update extension meta information
 
@@ -311,10 +315,11 @@ To update the tags:
 Please use `./vendor/bin/tailor ter:update -h` to see the full
 list of available options.
 
-**Note:** All options set with this command will overwrite the
-existing data. Therefore, if you, for example, just want to add
-another tag, you have to add the current ones along with the new
-one. You can use `ter:details` to get the current state.
+> [!IMPORTANT]
+> All options set with this command will overwrite the
+> existing data. Therefore, if you, for example, just want to add
+> another tag, you have to add the current ones along with the new
+> one. You can use `ter:details` to get the current state.
 
 ### Transfer ownership of an extension to another user
 
@@ -338,8 +343,9 @@ Key: my_extension
 Owner: some_user
 ```
 
-**Note**: For automated workflows the confirmation can be
-skipped with the ``-n, --no-interaction`` option.
+> [!TIP]
+> For automated workflows the confirmation can be
+> skipped with the ``-n, --no-interaction`` option.
 
 ### Delete / abandon an extension
 
@@ -358,8 +364,9 @@ to the REST API.
 
 This will delete / abandon the extension `my_extension`.
 
-**Note**: For automated workflows the confirmation can be
-skipped with the ``-n, --no-interaction`` option.
+> [!TIP]
+> For automated workflows the confirmation can be
+> skipped with the ``-n, --no-interaction`` option.
 
 ### Find and filter extensions on TER
 
@@ -450,10 +457,11 @@ git push origin --tags
 ./vendor/bin/tailor ter:publish 1.5.0
 ```
 
-**Note:** Both `set-version` and `ter:publish` provide options
-to specify the location of your extension. If, like in the example
-above, non is set, Tailor automatically uses your current working
-directory.
+> [!NOTE]
+> Both `set-version` and `ter:publish` provide options
+> to specify the location of your extension. If, like in the example
+> above, non is set, Tailor automatically uses your current working
+> directory.
 
 ## Publish a new version using your CI
 
@@ -477,10 +485,11 @@ The workflow furthermore requires the GitHub secrets `TYPO3_EXTENSION_KEY`
 and `TYPO3_API_TOKEN` to be set. Add them at "Settings -> Secrets -> New
 repository secret".
 
-**Note**: If your `composer.json` file contains the extension key at
-`[extra][typo3/cms][extension-key] = 'my_key'` (this is good practice anyway),
-the `TYPO3_EXTENSION_KEY` secret and assignment in the below GitHub action
-example is not needed, tailor will pick it up.
+> [!NOTE]
+> If your `composer.json` file contains the extension key at
+> `[extra][typo3/cms][extension-key] = 'my_key'` (this is good practice anyway),
+> the `TYPO3_EXTENSION_KEY` secret and assignment in the below GitHub action
+> example is not needed, tailor will pick it up.
 
 The version is automatically fetched from the tag and
 validated to match the required pattern.
@@ -548,7 +557,8 @@ jobs:
         run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.comment }}" ${{ env.version }}
 ```
 
-**Note**: If you're using tags with a leading `v` the above example needs to be adjusted.
+> [!IMPORTANT]
+> If you're using tags with a leading `v` the above example needs to be adjusted.
 
 1. The regular expression in step **Check tag** should be:
 
@@ -583,10 +593,11 @@ The upload comment is taken from the message in the tag.
 The job furthermore requires the GitLab variables
 `TYPO3_EXTENSION_KEY` and `TYPO3_API_TOKEN` to be set.
 
-**Note**: If your `composer.json` file contains your extension
-key, you can remove the `TYPO3_EXTENSION_KEY` variable, the
-check and the assignment in the GitLab pipeline, since Tailor
-automatically fetches this key then.
+> [!NOTE]
+> If your `composer.json` file contains your extension
+> key, you can remove the `TYPO3_EXTENSION_KEY` variable, the
+> check and the assignment in the GitLab pipeline, since Tailor
+> automatically fetches this key then.
 
 The variable `CI_COMMIT_TAG` is set by GitLab automatically.
 
@@ -610,6 +621,17 @@ The variable `CI_COMMIT_TAG` is set by GitLab automatically.
         /tmp/vendor/bin/tailor ter:publish --comment "$TAG_MESSAGE" "$CI_COMMIT_TAG" "$TYPO3_EXTENSION_KEY"
       fi;
 ```
+
+## Exclude paths from packaging
+
+A couple of directories and files are excluded
+from packaging by default. You can find the configuration in
+[`conf/ExcludeFromPackaging.php`](conf/ExcludeFromPackaging.php).
+
+If you like, you can also use a custom configuration. Just add the
+path to your custom configuration file to the environment variable
+`TYPO3_EXCLUDE_FROM_PACKAGING`. This file must return an
+`array` with the keys `directories` and `files` on root level.
 
 ## Overview of all available commands
 

--- a/bin/tailor
+++ b/bin/tailor
@@ -36,6 +36,7 @@ foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php
     $application->add(new Command\Auth\CreateTokenCommand('ter:token:create'));
     $application->add(new Command\Auth\RefreshTokenCommand('ter:token:refresh'));
     $application->add(new Command\Auth\RevokeTokenCommand('ter:token:revoke'));
+    $application->add(new Command\Extension\CreateExtensionArtefactCommand('create-artefact'));
     $application->add(new Command\Extension\DeleteExtensionCommand('ter:delete'));
     $application->add(new Command\Extension\ExtensionDetailsCommand('ter:details'));
     $application->add(new Command\Extension\ExtensionVersionsCommand('ter:versions'));

--- a/conf/ExcludeFromPackaging.php
+++ b/conf/ExcludeFromPackaging.php
@@ -21,6 +21,7 @@ return [
         'bin',
         'build',
         'public',
+        'tailor-version-artefact',
         'tailor-version-upload',
         'tests',
         'tools',

--- a/src/Command/AbstractClientRequestCommand.php
+++ b/src/Command/AbstractClientRequestCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,7 +28,7 @@ use TYPO3\Tailor\Writer\ConsoleWriter;
 /**
  * Abstract class to be used by commands, requesting an TER API endpoint
  */
-abstract class AbstractClientRequestCommand extends AbstractCommand
+abstract class AbstractClientRequestCommand extends Command
 {
     /** @var int */
     private $defaultAuthMethod = HttpClientFactory::ALL_AUTH;

--- a/src/Command/AbstractClientRequestCommand.php
+++ b/src/Command/AbstractClientRequestCommand.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Command;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,9 +19,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
-use TYPO3\Tailor\Environment\Variables;
-use TYPO3\Tailor\Exception\ExtensionKeyMissingException;
-use TYPO3\Tailor\Filesystem\ComposerReader;
 use TYPO3\Tailor\Formatter\ConsoleFormatter;
 use TYPO3\Tailor\HttpClientFactory;
 use TYPO3\Tailor\Service\RequestService;
@@ -31,7 +27,7 @@ use TYPO3\Tailor\Writer\ConsoleWriter;
 /**
  * Abstract class to be used by commands, requesting an TER API endpoint
  */
-abstract class AbstractClientRequestCommand extends Command
+abstract class AbstractClientRequestCommand extends AbstractCommand
 {
     /** @var int */
     private $defaultAuthMethod = HttpClientFactory::ALL_AUTH;
@@ -93,26 +89,6 @@ abstract class AbstractClientRequestCommand extends Command
     {
         $this->confirmationRequired = $confirmationRequired;
         return $this;
-    }
-
-    protected function getExtensionKey(InputInterface $input): string
-    {
-        if ($input->hasArgument('extensionkey')
-            && ($key = ($input->getArgument('extensionkey') ?? '')) !== ''
-        ) {
-            $extensionKey = $key;
-        } elseif (Variables::has('TYPO3_EXTENSION_KEY')) {
-            $extensionKey = Variables::get('TYPO3_EXTENSION_KEY');
-        } elseif (($extensionKeyFromComposer = (new ComposerReader())->getExtensionKey()) !== '') {
-            $extensionKey = $extensionKeyFromComposer;
-        } else {
-            throw new ExtensionKeyMissingException(
-                'The extension key must either be set as argument, as environment variable or in the composer.json.',
-                1605706548
-            );
-        }
-
-        return $extensionKey;
     }
 
     abstract protected function getRequestConfiguration(): RequestConfiguration;

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project - inspiring people to share!
+ * (c) 2020-2023 Oliver Bartsch, Benni Mack & Elias Häußler
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace TYPO3\Tailor\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use TYPO3\Tailor\Environment\Variables;
+use TYPO3\Tailor\Exception\ExtensionKeyMissingException;
+use TYPO3\Tailor\Filesystem\ComposerReader;
+
+/**
+ * Abstract class for tailor console commands.
+ */
+abstract class AbstractCommand extends Command
+{
+    protected function getExtensionKey(InputInterface $input): string
+    {
+        if ($input->hasArgument('extensionkey')
+            && ($key = ($input->getArgument('extensionkey') ?? '')) !== ''
+        ) {
+            $extensionKey = $key;
+        } elseif (Variables::has('TYPO3_EXTENSION_KEY')) {
+            $extensionKey = Variables::get('TYPO3_EXTENSION_KEY');
+        } elseif (($extensionKeyFromComposer = (new ComposerReader())->getExtensionKey()) !== '') {
+            $extensionKey = $extensionKeyFromComposer;
+        } else {
+            throw new ExtensionKeyMissingException(
+                'The extension key must either be set as argument, as environment variable or in the composer.json.',
+                1605706548
+            );
+        }
+
+        return $extensionKey;
+    }
+}

--- a/src/Command/Extension/CreateExtensionArtefactCommand.php
+++ b/src/Command/Extension/CreateExtensionArtefactCommand.php
@@ -65,7 +65,7 @@ class CreateExtensionArtefactCommand extends AbstractCommand
         $transactionPath = rtrim(realpath(getcwd() ?: './'), '/') . '/tailor-version-artefact';
 
         if (!(new Filesystem\Directory())->create($transactionPath)) {
-            throw new \RuntimeException(sprintf('Directory could not be created.'));
+            throw new \RuntimeException(sprintf('Directory could not be created: %s', $transactionPath));
         }
 
         $versionService = new VersionService($version, $extensionKey, $transactionPath);

--- a/src/Command/Extension/CreateExtensionArtefactCommand.php
+++ b/src/Command/Extension/CreateExtensionArtefactCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project - inspiring people to share!
+ * (c) 2020-2023 Oliver Bartsch, Benni Mack & Elias Häußler
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace TYPO3\Tailor\Command\Extension;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\Tailor\Command\AbstractCommand;
+use TYPO3\Tailor\Filesystem;
+use TYPO3\Tailor\Service\VersionService;
+
+/**
+ * Command to create a local extension artefact (zip archive).
+ */
+class CreateExtensionArtefactCommand extends AbstractCommand
+{
+    protected function configure(): void
+    {
+        $this->setDescription('Create an artefact file (zip archive) of an extension');
+
+        $this->addArgument(
+            'version',
+            InputArgument::REQUIRED,
+            'The version of the extension, e.g. 1.2.3'
+        );
+        $this->addArgument(
+            'extensionkey',
+            InputArgument::OPTIONAL,
+            'The extension key'
+        );
+        $this->addOption(
+            'path',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Path to the extension folder'
+        );
+        $this->addOption(
+            'artefact',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Path or URL to a zip file'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $version = $input->getArgument('version');
+        $extensionKey = $this->getExtensionKey($input);
+        $path = $input->getOption('path');
+        $artefact = $input->getOption('artefact');
+        $transactionPath = rtrim(realpath(getcwd() ?: './'), '/') . '/tailor-version-upload';
+
+        if (!(new Filesystem\Directory())->create($transactionPath)) {
+            throw new \RuntimeException(sprintf('Directory could not be created.'));
+        }
+
+        $versionService = new VersionService($version, $extensionKey, $transactionPath);
+
+        if ($path !== null) {
+            $versionService->createZipArchiveFromPath($path);
+        } elseif ($artefact !== null) {
+            $versionService->createZipArchiveFromArtefact($artefact);
+        } else {
+            // If neither `path` nor `artefact` are defined, we just
+            // create the ZipArchive from the current directory.
+            $versionService->createZipArchiveFromPath(getcwd() ?: './');
+        }
+
+        $io->success(sprintf('Extension artefact successfully generated: %s', $versionService->getVersionFilePath()));
+
+        return 0;
+    }
+}

--- a/src/Command/Extension/CreateExtensionArtefactCommand.php
+++ b/src/Command/Extension/CreateExtensionArtefactCommand.php
@@ -12,19 +12,20 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Command\Extension;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use TYPO3\Tailor\Command\AbstractCommand;
 use TYPO3\Tailor\Filesystem;
+use TYPO3\Tailor\Helper\CommandHelper;
 use TYPO3\Tailor\Service\VersionService;
 
 /**
  * Command to create a local extension artefact (zip archive).
  */
-class CreateExtensionArtefactCommand extends AbstractCommand
+class CreateExtensionArtefactCommand extends Command
 {
     protected function configure(): void
     {
@@ -59,7 +60,7 @@ class CreateExtensionArtefactCommand extends AbstractCommand
         $io = new SymfonyStyle($input, $output);
 
         $version = $input->getArgument('version');
-        $extensionKey = $this->getExtensionKey($input);
+        $extensionKey = CommandHelper::getExtensionKeyFromInput($input);
         $path = $input->getOption('path');
         $artefact = $input->getOption('artefact');
         $transactionPath = rtrim(realpath(getcwd() ?: './'), '/') . '/tailor-version-artefact';

--- a/src/Command/Extension/CreateExtensionArtefactCommand.php
+++ b/src/Command/Extension/CreateExtensionArtefactCommand.php
@@ -62,7 +62,7 @@ class CreateExtensionArtefactCommand extends AbstractCommand
         $extensionKey = $this->getExtensionKey($input);
         $path = $input->getOption('path');
         $artefact = $input->getOption('artefact');
-        $transactionPath = rtrim(realpath(getcwd() ?: './'), '/') . '/tailor-version-upload';
+        $transactionPath = rtrim(realpath(getcwd() ?: './'), '/') . '/tailor-version-artefact';
 
         if (!(new Filesystem\Directory())->create($transactionPath)) {
             throw new \RuntimeException(sprintf('Directory could not be created.'));

--- a/src/Command/Extension/DeleteExtensionCommand.php
+++ b/src/Command/Extension/DeleteExtensionCommand.php
@@ -19,6 +19,7 @@ use TYPO3\Tailor\Command\AbstractClientRequestCommand;
 use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
 use TYPO3\Tailor\Formatter\ConsoleFormatter;
+use TYPO3\Tailor\Helper\CommandHelper;
 
 /**
  * Command for TER REST endpoint `DELETE /extension/{key}`
@@ -40,7 +41,7 @@ class DeleteExtensionCommand extends AbstractClientRequestCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->extensionKey = $this->getExtensionKey($input);
+        $this->extensionKey = CommandHelper::getExtensionKeyFromInput($input);
         return parent::execute($input, $output);
     }
 

--- a/src/Command/Extension/ExtensionDetailsCommand.php
+++ b/src/Command/Extension/ExtensionDetailsCommand.php
@@ -19,6 +19,7 @@ use TYPO3\Tailor\Command\AbstractClientRequestCommand;
 use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
 use TYPO3\Tailor\Formatter\ConsoleFormatter;
+use TYPO3\Tailor\Helper\CommandHelper;
 
 /**
  * Command for TER REST endpoint `GET /extension/{key}`
@@ -39,7 +40,7 @@ class ExtensionDetailsCommand extends AbstractClientRequestCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->extensionKey = $this->getExtensionKey($input);
+        $this->extensionKey = CommandHelper::getExtensionKeyFromInput($input);
         return parent::execute($input, $output);
     }
 

--- a/src/Command/Extension/ExtensionVersionsCommand.php
+++ b/src/Command/Extension/ExtensionVersionsCommand.php
@@ -19,6 +19,7 @@ use TYPO3\Tailor\Command\AbstractClientRequestCommand;
 use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
 use TYPO3\Tailor\Formatter\ConsoleFormatter;
+use TYPO3\Tailor\Helper\CommandHelper;
 
 /**
  * Command for TER REST endpoint `GET /extension/{key}/versions`
@@ -39,7 +40,7 @@ class ExtensionVersionsCommand extends AbstractClientRequestCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->extensionKey = $this->getExtensionKey($input);
+        $this->extensionKey = CommandHelper::getExtensionKeyFromInput($input);
         // @todo the response format needs to be adjusted!
         return parent::execute($input, $output);
     }

--- a/src/Command/Extension/RegisterExtensionCommand.php
+++ b/src/Command/Extension/RegisterExtensionCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\Tailor\Command\AbstractClientRequestCommand;
 use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
+use TYPO3\Tailor\Helper\CommandHelper;
 
 /**
  * Command for TER REST endpoint `POST /extension/{key}`
@@ -37,7 +38,7 @@ class RegisterExtensionCommand extends AbstractClientRequestCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->extensionKey = $this->getExtensionKey($input);
+        $this->extensionKey = CommandHelper::getExtensionKeyFromInput($input);
         return parent::execute($input, $output);
     }
 

--- a/src/Command/Extension/TransferExtensionCommand.php
+++ b/src/Command/Extension/TransferExtensionCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\Tailor\Command\AbstractClientRequestCommand;
 use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
+use TYPO3\Tailor\Helper\CommandHelper;
 
 /**
  * Command for TER REST endpoint `POST /extension/{key}/transfer/{username}`
@@ -43,7 +44,7 @@ class TransferExtensionCommand extends AbstractClientRequestCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->username = $input->getArgument('username');
-        $this->extensionKey = $this->getExtensionKey($input);
+        $this->extensionKey = CommandHelper::getExtensionKeyFromInput($input);
         return parent::execute($input, $output);
     }
 

--- a/src/Command/Extension/UpdateExtensionCommand.php
+++ b/src/Command/Extension/UpdateExtensionCommand.php
@@ -20,6 +20,7 @@ use TYPO3\Tailor\Command\AbstractClientRequestCommand;
 use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
 use TYPO3\Tailor\Formatter\ConsoleFormatter;
+use TYPO3\Tailor\Helper\CommandHelper;
 
 /**
  * Command for TER REST endpoint `PUT /extension/{key}`
@@ -55,7 +56,7 @@ class UpdateExtensionCommand extends AbstractClientRequestCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->extensionKey = $this->getExtensionKey($input);
+        $this->extensionKey = CommandHelper::getExtensionKeyFromInput($input);
         return parent::execute($input, $output);
     }
 

--- a/src/Command/Extension/UploadExtensionVersionCommand.php
+++ b/src/Command/Extension/UploadExtensionVersionCommand.php
@@ -23,6 +23,7 @@ use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
 use TYPO3\Tailor\Filesystem;
 use TYPO3\Tailor\Formatter\ConsoleFormatter;
+use TYPO3\Tailor\Helper\CommandHelper;
 use TYPO3\Tailor\Service\VersionService;
 
 /**
@@ -56,7 +57,7 @@ class UploadExtensionVersionCommand extends AbstractClientRequestCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->version = $input->getArgument('version');
-        $this->extensionKey = $this->getExtensionKey($input);
+        $this->extensionKey = CommandHelper::getExtensionKeyFromInput($input);
         $this->transactionPath = rtrim(realpath(getcwd() ?: './'), '/') . '/tailor-version-upload';
 
         if (!(new Filesystem\Directory())->create($this->transactionPath)) {

--- a/src/Command/Extension/VersionDetailsCommand.php
+++ b/src/Command/Extension/VersionDetailsCommand.php
@@ -19,6 +19,7 @@ use TYPO3\Tailor\Command\AbstractClientRequestCommand;
 use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
 use TYPO3\Tailor\Formatter\ConsoleFormatter;
+use TYPO3\Tailor\Helper\CommandHelper;
 
 /**
  * Command for TER REST endpoint `GET /extension/{key}/{version}`
@@ -44,7 +45,7 @@ class VersionDetailsCommand extends AbstractClientRequestCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->version = $input->getArgument('version');
-        $this->extensionKey = $this->getExtensionKey($input);
+        $this->extensionKey = CommandHelper::getExtensionKeyFromInput($input);
         return parent::execute($input, $output);
     }
 

--- a/src/Helper/CommandHelper.php
+++ b/src/Helper/CommandHelper.php
@@ -4,26 +4,25 @@ declare(strict_types=1);
 
 /*
  * This file is part of the TYPO3 project - inspiring people to share!
- * (c) 2020-2023 Oliver Bartsch, Benni Mack & Elias Häußler
+ * (c) 2020-2024 Oliver Bartsch, Benni Mack & Elias Häußler
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace TYPO3\Tailor\Command;
+namespace TYPO3\Tailor\Helper;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use TYPO3\Tailor\Environment\Variables;
 use TYPO3\Tailor\Exception\ExtensionKeyMissingException;
 use TYPO3\Tailor\Filesystem\ComposerReader;
 
 /**
- * Abstract class for tailor console commands.
+ * Helper class for console commands.
  */
-abstract class AbstractCommand extends Command
+final class CommandHelper
 {
-    protected function getExtensionKey(InputInterface $input): string
+    public static function getExtensionKeyFromInput(InputInterface $input): string
     {
         if ($input->hasArgument('extensionkey')
             && ($key = ($input->getArgument('extensionkey') ?? '')) !== ''

--- a/tests/Unit/Helper/CommandHelperTest.php
+++ b/tests/Unit/Helper/CommandHelperTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project - inspiring people to share!
+ * (c) 2020-2024 Oliver Bartsch, Benni Mack & Elias Häußler
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace TYPO3\Tailor\Tests\Unit\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use TYPO3\Tailor\Exception\ExtensionKeyMissingException;
+use TYPO3\Tailor\Helper\CommandHelper;
+
+final class CommandHelperTest extends TestCase
+{
+    /**
+     * @var InputDefinition
+     */
+    private $definition;
+
+    /**
+     * @var ArrayInput
+     */
+    private $input;
+
+    protected function setUp(): void
+    {
+        $this->definition = new InputDefinition();
+        $this->input = new ArrayInput([], $this->definition);
+    }
+
+    /**
+     * @test
+     */
+    public function getExtensionKeyFromInputThrowsExceptionIfInputHasNoArgumentDefined(): void
+    {
+        $this->expectException(ExtensionKeyMissingException::class);
+        $this->expectExceptionMessage('The extension key must either be set as argument, as environment variable or in the composer.json.');
+        $this->expectExceptionCode(1605706548);
+
+        CommandHelper::getExtensionKeyFromInput($this->input);
+    }
+
+    /**
+     * @test
+     */
+    public function getExtensionKeyFromInputReturnsExtensionKeyFromInputArgument(): void
+    {
+        $this->definition->addArgument(new InputArgument('extensionkey', InputArgument::REQUIRED));
+        $this->input->setArgument('extensionkey', 'foo');
+
+        self::assertSame('foo', CommandHelper::getExtensionKeyFromInput($this->input));
+    }
+
+    /**
+     * @test
+     */
+    public function getExtensionKeyFromInputIgnoresEmptyInputArgumentValue(): void
+    {
+        $this->expectException(ExtensionKeyMissingException::class);
+        $this->expectExceptionMessage('The extension key must either be set as argument, as environment variable or in the composer.json.');
+        $this->expectExceptionCode(1605706548);
+
+        $this->definition->addArgument(new InputArgument('extensionkey', InputArgument::OPTIONAL));
+        $this->input->setArgument('extensionkey', '');
+
+        CommandHelper::getExtensionKeyFromInput($this->input);
+    }
+
+    /**
+     * @test
+     */
+    public function getExtensionKeyFromInputReturnsExtensionKeyFromEnvironmentVariables(): void
+    {
+        putenv('TYPO3_EXTENSION_KEY=foo');
+
+        self::assertSame('foo', CommandHelper::getExtensionKeyFromInput($this->input));
+
+        putenv('TYPO3_EXTENSION_KEY');
+    }
+}


### PR DESCRIPTION
This PR adds a new `create-artefact` command. It can be used to create a local artefact file (zip archive) of an extension. This is basically the same which is already done in the `ter:publish` command, except for the TER publish part.

The new command is especially useful to test custom configurations of package exclude files. In addition, it's a useful helper in cases where the TER REST API might not be accessible.