### PR TITLE
[BUGFIX] Fix multiline comments for GitHub environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,11 @@ jobs:
           if [[ -z "${comment// }" ]]; then
             echo "comment=Released version ${{ env.version }} of ${{ env.TYPO3_EXTENSION_KEY }}" >> $GITHUB_ENV
           else
-            echo "comment=$comment" >> $GITHUB_ENV
+            {
+              echo 'comment<<EOF'
+              echo "$comment"
+              echo EOF
+            } >> "$GITHUB_ENV"
           fi
 
       - name: Setup PHP


### PR DESCRIPTION
Multiline strings require a special syntax with delimiter:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings