### PR TITLE
[FEATURE] Provide detailed error messages for `ext_emconf.php` validation

### DIFF
--- a/src/Validation/EmConfValidationError.php
+++ b/src/Validation/EmConfValidationError.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project  - inspiring people to share!
+ * (c) 2020 Oliver Bartsch & Benni Mack
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace TYPO3\Tailor\Validation;
+
+/**
+ * Enum with validation errors of ext_emconf.php files.
+ *
+ * @todo Convert to native enum once support for PHP < 8.1 is dropped.
+ */
+abstract class EmConfValidationError
+{
+    public const EXTENSION_VERSION_MISMATCH = 'extension-version-mismatch';
+    public const MISSING_CONFIGURATION = 'missing-configuration';
+    public const MISSING_EXTENSION_VERSION = 'missing-version';
+    public const MISSING_TYPO3_VERSION_CONSTRAINT = 'missing-typo3-version-constraint';
+    public const NOT_FOUND = 'not-found';
+    public const UNSUPPORTED_TYPE = 'unsupported-type';
+
+    public static function getErrorMessage(string $error): string
+    {
+        switch ($error) {
+            case self::EXTENSION_VERSION_MISMATCH:
+                return 'The configured version in `ext_emconf.php` file does not match the given version for release.';
+            case self::MISSING_CONFIGURATION:
+                return 'The `ext_emconf.php` file is missing an $EM_CONF configuration array.';
+            case self::MISSING_EXTENSION_VERSION:
+                return 'No version configured in `ext_emconf.php` file.';
+            case self::MISSING_TYPO3_VERSION_CONSTRAINT:
+                return 'No TYPO3 version constraint configured in `ext_emconf.php` file.';
+            case self::NOT_FOUND:
+                return 'No `ext_emconf.php` file found in the folder.';
+            case self::UNSUPPORTED_TYPE:
+                return 'The $EM_CONF variable in `ext_emconf.php` file contains an unsupported type (should be an array).';
+            default:
+                // @todo Can be removed once this class is converted to a native enum.
+                return 'An unexpected error occurred while reading the `ext_emconf.php` file.';
+        }
+    }
+}

--- a/tests/Unit/Fixtures/EmConf/emconf_no_version.php
+++ b/tests/Unit/Fixtures/EmConf/emconf_no_version.php
@@ -1,5 +1,5 @@
 <?php
 
-$EM_CONF = [
+$EM_CONF[$_EXTKEY] = [
     'nothing' => 'YES',
 ];

--- a/tests/Unit/Validation/EmConfVersionValidatorTest.php
+++ b/tests/Unit/Validation/EmConfVersionValidatorTest.php
@@ -13,10 +13,73 @@ declare(strict_types=1);
 namespace TYPO3\Tailor\Tests\Unit\Validation;
 
 use PHPUnit\Framework\TestCase;
+use TYPO3\Tailor\Validation\EmConfValidationError;
 use TYPO3\Tailor\Validation\EmConfVersionValidator;
 
 class EmConfVersionValidatorTest extends TestCase
 {
+    /**
+     * @test
+     */
+    public function collectErrorsReturnsErrorIfFileDoesNotExist(): void
+    {
+        $subject = new EmConfVersionValidator(__DIR__ . '/no-file');
+        $expected = [EmConfValidationError::NOT_FOUND];
+        self::assertSame($expected, $subject->collectErrors('1.2.0'));
+    }
+
+    /**
+     * @test
+     */
+    public function collectErrorsReturnsErrorIfConfigurationIsMissing(): void
+    {
+        $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_invalid.php');
+        $expected = [EmConfValidationError::MISSING_CONFIGURATION];
+        self::assertSame($expected, $subject->collectErrors('1.0.0'));
+    }
+
+    /**
+     * @test
+     */
+    public function collectErrorsReturnsErrorIfFileDoesNotMatchEmConfStructure(): void
+    {
+        $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_no_structure.php');
+        $expected = [EmConfValidationError::UNSUPPORTED_TYPE];
+        self::assertSame($expected, $subject->collectErrors('1.0.0'));
+    }
+
+    /**
+     * @test
+     */
+    public function collectErrorsReturnsErrorsIfNoVersionGiven(): void
+    {
+        $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_no_version.php');
+        $expected = [
+            EmConfValidationError::MISSING_EXTENSION_VERSION,
+            EmConfValidationError::MISSING_TYPO3_VERSION_CONSTRAINT,
+        ];
+        self::assertSame($expected, $subject->collectErrors('1.0.0'));
+    }
+
+    /**
+     * @test
+     */
+    public function collectErrorsReturnsErrorIfVersionsDoNotMatch(): void
+    {
+        $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_valid.php');
+        $expected = [EmConfValidationError::EXTENSION_VERSION_MISMATCH];
+        self::assertSame($expected, $subject->collectErrors('2.0.0'));
+    }
+
+    /**
+     * @test
+     */
+    public function collectErrorsReturnsEmptyArrayIfFileIsValid(): void
+    {
+        $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_valid.php');
+        self::assertSame([], $subject->collectErrors('1.0.0'));
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
This PR proposes a more fine-grained way of `ext_emconf.php` file validation. A new `EmConfValidationError` class is introduced (can be converted to a native enum once support for PHP < 8.1 is dropped) which provides a set of possible validation errors. These errors are collected in a new `EmConfVersionValidator::collectErrors()` method and will be displayed in `VersionService` instead of the previously used generic error message. This allows users to easily find and solve configuration mismatches in `ext_emconf.php` file.

Example:

![image](https://github.com/user-attachments/assets/f6046908-49b0-4960-ad18-c803b2908f45)

Resolves: #52