### PR TITLE
[TASK] Add PHP 8.4 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds PHP 8.4 to the test matrix to assure compatibility with PHP 8.4. CGL are still checked using PHP 8.3 since [PHP-CS-Fixer does not yet support PHP 8.4](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/168ac89555dc3bdd9f37a89dbd38457bef85a8ff/php-cs-fixer#L32).