### PR TITLE
[TASK] Fix codestyle according to updated PHP-CS-Fixer ruleset

### DIFF
--- a/src/Filesystem/Directory.php
+++ b/src/Filesystem/Directory.php
@@ -12,10 +12,6 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Filesystem;
 
-use FilesystemIterator;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-
 /**
  * Provide functionality for handling directories on the filesystem
  */
@@ -42,9 +38,9 @@ class Directory
     public function remove(string $directory): bool
     {
         $directory = realpath($directory);
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
         );
 
         foreach ($iterator as $file) {

--- a/src/Filesystem/VersionReplacer.php
+++ b/src/Filesystem/VersionReplacer.php
@@ -43,7 +43,7 @@ class VersionReplacer
         if ($fileContents === false) {
             throw new \InvalidArgumentException('The file ' . $filePath . ' could not be opened', 1605741968);
         }
-        $updatedFileContents = preg_replace_callback('/' . $pattern . '/u', static function($matches) use ($newVersion) {
+        $updatedFileContents = preg_replace_callback('/' . $pattern . '/u', static function ($matches) use ($newVersion) {
             return str_replace($matches[1], $newVersion, $matches[0]);
         }, $fileContents);
         file_put_contents($filePath, $updatedFileContents);

--- a/src/Service/VersionService.php
+++ b/src/Service/VersionService.php
@@ -12,10 +12,6 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Service;
 
-use FilesystemIterator;
-use RecursiveCallbackFilterIterator;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use TYPO3\Tailor\Environment\Variables;
 use TYPO3\Tailor\Exception\FormDataProcessingException;
 use TYPO3\Tailor\Exception\RequiredConfigurationMissing;
@@ -64,14 +60,14 @@ class VersionService
             throw new FormDataProcessingException('Path is not valid.', 1605562741);
         }
 
-        $zipArchive = new ZipArchive();
-        $zipArchive->open($this->getVersionFilename(), ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zipArchive = new \ZipArchive();
+        $zipArchive->open($this->getVersionFilename(), \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
 
         $emConfValid = false;
 
-        $iterator = new RecursiveDirectoryIterator($fullPath, FilesystemIterator::SKIP_DOTS);
-        $files = new RecursiveIteratorIterator(
-            new RecursiveCallbackFilterIterator($iterator, function($current) use ($fullPath) {
+        $iterator = new \RecursiveDirectoryIterator($fullPath, \FilesystemIterator::SKIP_DOTS);
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveCallbackFilterIterator($iterator, function ($current) use ($fullPath) {
                 // @todo Find a more performant way for filtering
 
                 $filepath = $current->getRealPath();
@@ -101,7 +97,7 @@ class VersionService
 
                 return true;
             }),
-            RecursiveIteratorIterator::LEAVES_ONLY
+            \RecursiveIteratorIterator::LEAVES_ONLY
         );
 
         foreach ($files as $file) {
@@ -157,7 +153,7 @@ class VersionService
         if (!is_file($filename)) {
             throw new FormDataProcessingException('No such file.', 1605562482);
         }
-        $zipArchive = new ZipArchive();
+        $zipArchive = new \ZipArchive();
         $zipFile = $zipArchive->open($filename);
         if (!$zipFile || $zipArchive->numFiles <= 0) {
             throw new FormDataProcessingException('No files in given directory.', 1605562663);

--- a/tests/Unit/Service/VersionServiceTest.php
+++ b/tests/Unit/Service/VersionServiceTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace TYPO3\Tailor\Tests\Unit\Service;
 
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 use TYPO3\Tailor\Exception\RequiredConfigurationMissing;
 use TYPO3\Tailor\Service\VersionService;
 
@@ -135,7 +134,7 @@ class VersionServiceTest extends TestCase
             ->setConstructorArgs(['1.0.0', 'my_ext', '/dummyPath'])
             ->getMock();
 
-        $method = new ReflectionMethod(VersionService::class, $methodName);
+        $method = new \ReflectionMethod(VersionService::class, $methodName);
         $method->setAccessible(true);
 
         return $method->invokeArgs($mock, $arguments);


### PR DESCRIPTION
Rulesets in `typo3/coding-standards` and PHP-CS-Fixer have changed in the meantime, therefore source files needed to be fixed.