### PR TITLE
[FEATURE] Support guides.xml in documentation version replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,11 @@ be done using the `set-version` command.
 ./vendor/bin/tailor set-version 1.2.0
 ```
 
-If your extension also contains a `Documentation/Settings.cfg`
-file, the command will also update the `release` and `version`
-information in it. You can disable this feature by either
-using `--no-docs` or by setting the environment variable
-`TYPO3_DISABLE_DOCS_VERSION_UPDATE=1`.
+If your extension also contains a `Documentation/guides.xml`
+or `Documentation/Settings.cfg` file, the command will also
+update the `release` and `version` information in it. You
+can disable this feature by either using `--no-docs` or by
+setting the environment variable `TYPO3_DISABLE_DOCS_VERSION_UPDATE=1`.
 
 > [!TIP]
 > It's also possible to use the `--path` option to

--- a/tests/Unit/Filesystem/VersionReplacerTest.php
+++ b/tests/Unit/Filesystem/VersionReplacerTest.php
@@ -33,32 +33,58 @@ class VersionReplacerTest extends TestCase
     }
 
     /**
-     * @test
+     * @return \Generator<string, array{string, string, string}>
      */
-    public function replaceVersionReplacesProperReleaseOfDocumentationConfiguration(): void
+    public static function replaceVersionReplacesProperReleaseOfDocumentationConfigurationDataProvider(): \Generator
     {
-        $docSettings = file_get_contents(__DIR__ . '/../Fixtures/Documentation/Settings.cfg');
-        $tempFile = tempnam('/tmp/', 'tailor_settings.cfg');
-        file_put_contents($tempFile, $docSettings);
-        $subject = new VersionReplacer('6.9.0');
-        $subject->setVersion($tempFile, 'release\s*=\s*([0-9]+\.[0-9]+\.[0-9]+)');
-        $contents = file_get_contents($tempFile);
-        self::assertStringContainsString('release=6.9.0', preg_replace('/\s+/', '', $contents));
-        unlink($tempFile);
+        yield 'guides.xml' => ['guides.xml', 'release="([0-9]+\.[0-9]+\.[0-9]+)"', 'release="6.9.0"'];
+        yield 'Settings.cfg' => ['Settings.cfg', 'release\s*=\s*([0-9]+\.[0-9]+\.[0-9]+)', 'release=6.9.0'];
     }
 
     /**
      * @test
+     * @dataProvider replaceVersionReplacesProperReleaseOfDocumentationConfigurationDataProvider
      */
-    public function replaceVersionReplacesProperVersionOfDocumentationConfiguration(): void
-    {
-        $docSettings = file_get_contents(__DIR__ . '/../Fixtures/Documentation/Settings.cfg');
-        $tempFile = tempnam('/tmp/', 'tailor_settings.cfg');
+    public function replaceVersionReplacesProperReleaseOfDocumentationConfiguration(
+        string $docSettingsFile,
+        string $docReleasePattern,
+        string $expected
+    ): void {
+        $docSettings = file_get_contents(__DIR__ . '/../Fixtures/Documentation/' . $docSettingsFile);
+        $tempFile = tempnam(sys_get_temp_dir(), 'tailor_' . $docSettingsFile);
         file_put_contents($tempFile, $docSettings);
         $subject = new VersionReplacer('6.9.0');
-        $subject->setVersion($tempFile, 'version\s*=\s*([0-9]+\.[0-9]+)', 2);
+        $subject->setVersion($tempFile, $docReleasePattern);
         $contents = file_get_contents($tempFile);
-        self::assertStringContainsString('version=6.9', preg_replace('/\s+/', '', $contents));
+        self::assertStringContainsString($expected, preg_replace('/\s+/', '', $contents));
+        unlink($tempFile);
+    }
+
+    /**
+     * @return \Generator<string, array{string, string, string}>
+     */
+    public static function replaceVersionReplacesProperVersionOfDocumentationConfigurationDataProvider(): \Generator
+    {
+        yield 'guides.xml' => ['guides.xml', 'version="([0-9]+\.[0-9]+)"', 'version="6.9"'];
+        yield 'Settings.cfg' => ['Settings.cfg', 'version\s*=\s*([0-9]+\.[0-9]+)', 'version=6.9'];
+    }
+
+    /**
+     * @test
+     * @dataProvider replaceVersionReplacesProperVersionOfDocumentationConfigurationDataProvider
+     */
+    public function replaceVersionReplacesProperVersionOfDocumentationConfiguration(
+        string $docSettingsFile,
+        string $docVersionPattern,
+        string $expected
+    ): void {
+        $docSettings = file_get_contents(__DIR__ . '/../Fixtures/Documentation/' . $docSettingsFile);
+        $tempFile = tempnam(sys_get_temp_dir(), 'tailor_' . $docSettingsFile);
+        file_put_contents($tempFile, $docSettings);
+        $subject = new VersionReplacer('6.9.0');
+        $subject->setVersion($tempFile, $docVersionPattern, 2);
+        $contents = file_get_contents($tempFile);
+        self::assertStringContainsString($expected, preg_replace('/\s+/', '', $contents));
         unlink($tempFile);
     }
 

--- a/tests/Unit/Fixtures/Documentation/guides.xml
+++ b/tests/Unit/Fixtures/Documentation/guides.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides ../vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd"
+        links-are-relative="true"
+>
+    <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"/>
+    <project
+            title="My extension"
+            release="1.0.0"
+            version="1.0"
+            copyright="2021"/>
+</guides>


### PR DESCRIPTION
This PR adds support for version replacement in `Documentation/guides.xml` files, in addition to version replacement in legacy `Documentation/Settings.cfg` files.