### PR TITLE
[BUGFIX] Fix upload to TER

### DIFF
--- a/src/Command/Extension/UploadExtensionVersionCommand.php
+++ b/src/Command/Extension/UploadExtensionVersionCommand.php
@@ -24,6 +24,7 @@ use TYPO3\Tailor\Dto\RequestConfiguration;
 use TYPO3\Tailor\Filesystem;
 use TYPO3\Tailor\Formatter\ConsoleFormatter;
 use TYPO3\Tailor\Helper\CommandHelper;
+use TYPO3\Tailor\HttpClientFactory;
 use TYPO3\Tailor\Service\VersionService;
 
 /**
@@ -75,8 +76,11 @@ class UploadExtensionVersionCommand extends AbstractClientRequestCommand
             'POST',
             'extension/' . $this->extensionKey . '/' . $this->version,
             [],
-            $formDataPart->bodyToIterable(),
-            $formDataPart->getPreparedHeaders()->toArray()
+            [],
+            [],
+            false,
+            HttpClientFactory::ALL_AUTH,
+            $formDataPart
         );
     }
 

--- a/src/Dto/RequestConfiguration.php
+++ b/src/Dto/RequestConfiguration.php
@@ -59,7 +59,7 @@ class RequestConfiguration
         iterable $headers = [],
         bool $raw = false,
         int $defaultAuthMethod = HttpClientFactory::ALL_AUTH,
-        FormDataPart $formData = null
+        ?FormDataPart $formData = null
     ) {
         $this->method = $method;
         $this->endpoint = $endpoint;

--- a/src/HttpClientFactory.php
+++ b/src/HttpClientFactory.php
@@ -48,6 +48,8 @@ final class HttpClientFactory
         }
         if ($requestConfiguration->getBody() !== []) {
             $options['body'] = $requestConfiguration->getBody();
+        } elseif ($requestConfiguration->getFormData()) {
+            $options['body'] = $requestConfiguration->getFormData()->bodyToString();
         }
         if (($defaultAuthMethod === self::BEARER_AUTH || $defaultAuthMethod === self::ALL_AUTH)
             && Variables::has('TYPO3_API_TOKEN')


### PR DESCRIPTION
This commit adapts some changes when uploading
a new version of extension.

Symfony's HTTP Client did not send the
Content-Type header properly, and also did
not send the body as string, but as iterable/array which does not work anymore and is adapted
to a string.

Fixes: #82