### PR TITLE
[BUGFIX] Avoid bumping extension version in XML prolog

### DIFF
--- a/src/Command/Extension/SetExtensionVersionCommand.php
+++ b/src/Command/Extension/SetExtensionVersionCommand.php
@@ -32,7 +32,7 @@ class SetExtensionVersionCommand extends Command
 
     // Documentation/guides.xml
     private const DOCUMENTATION_RELEASE_PATTERN = 'release="([0-9]+\.[0-9]+\.[0-9]+)"';
-    private const DOCUMENTATION_VERSION_PATTERN = 'version="([0-9]+\.[0-9]+)"';
+    private const DOCUMENTATION_VERSION_PATTERN = '(?<!xml )version="([0-9]+\.[0-9]+)"';
 
     // Documentation/Settings.cfg
     private const DOCUMENTATION_RELEASE_LEGACY_PATTERN = 'release\s*=\s*([0-9]+\.[0-9]+\.[0-9]+)';


### PR DESCRIPTION
This PR fixes an issue with the `set-version` command which previously bumped all `version="x.y"` occurrences in `Documentation/guides.xml`, leading to an invalid version number in the XML prolog.

## Example

Bumping an extension version from `5.3.3` to `5.4.0`.

### Before

```diff
diff --git a/Documentation/guides.xml b/Documentation/guides.xml
index 7502019b..b682eac0 100644
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="5.4" encoding="UTF-8"?>
 <guides xmlns="https://www.phpdoc.org/guides"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.phpdoc.org/guides ../.Build/vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd"
@@ -14,7 +14,7 @@
                typo3-core-preferred="main"
                interlink-shortcode="eliashaeussler/typo3-warming"
     />
-    <project title="Warming" version="5.3" release="5.3.3" copyright="since 2021 by Elias Häußler"/>
+    <project title="Warming" version="5.4" release="5.4.0" copyright="since 2021 by Elias Häußler"/>
     <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
     <inventory id="t3tsref" url="https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/"/>
     <inventory id="sitemap-locator" url="https://docs.typo3.org/p/eliashaeussler/typo3-sitemap-locator/main/en-us/"/>

```

### After

```diff
diff --git a/Documentation/guides.xml b/Documentation/guides.xml
index 7502019b..cb9234d6 100644
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -14,7 +14,7 @@
                typo3-core-preferred="main"
                interlink-shortcode="eliashaeussler/typo3-warming"
     />
-    <project title="Warming" version="5.3" release="5.3.3" copyright="since 2021 by Elias Häußler"/>
+    <project title="Warming" version="5.4" release="5.4.0" copyright="since 2021 by Elias Häußler"/>
     <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/"/>
     <inventory id="t3tsref" url="https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/"/>
     <inventory id="sitemap-locator" url="https://docs.typo3.org/p/eliashaeussler/typo3-sitemap-locator/main/en-us/"/>
```