### PR TITLE
Update PHPUnit to v11, raise PHP version to 8.2, and update Symfony support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+        php: ["8.2", "8.3", "8.4", "8.5"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.phpunit.result.cache
 /composer.lock
 /vendor
+/.phpunit.cache/

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.2
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
 

--- a/bin/tailor
+++ b/bin/tailor
@@ -20,7 +20,7 @@ foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php
     }
 }
 
-\call_user_func(static function() {
+call_user_func(static function () {
     foreach ([ __DIR__ . '/../.env', __DIR__ . '/../../../../.env', __DIR__ . '/../../../../../.env'] as $file) {
         if (file_exists($file)) {
             $dotEnv = (new Dotenv())->usePutenv();

--- a/bin/tailor
+++ b/bin/tailor
@@ -29,19 +29,27 @@ foreach ([__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php
         }
     }
     $application = new Application('Tailor - Your TYPO3 Extension Helper', '1.6.0');
-    $application->add(new Command\Auth\CreateTokenCommand('ter:token:create'));
-    $application->add(new Command\Auth\RefreshTokenCommand('ter:token:refresh'));
-    $application->add(new Command\Auth\RevokeTokenCommand('ter:token:revoke'));
-    $application->add(new Command\Extension\CreateExtensionArtefactCommand('create-artefact'));
-    $application->add(new Command\Extension\DeleteExtensionCommand('ter:delete'));
-    $application->add(new Command\Extension\ExtensionDetailsCommand('ter:details'));
-    $application->add(new Command\Extension\ExtensionVersionsCommand('ter:versions'));
-    $application->add(new Command\Extension\FindExtensionsCommand('ter:find'));
-    $application->add(new Command\Extension\RegisterExtensionCommand('ter:register'));
-    $application->add(new Command\Extension\SetExtensionVersionCommand('set-version'));
-    $application->add(new Command\Extension\TransferExtensionCommand('ter:transfer'));
-    $application->add(new Command\Extension\UpdateExtensionCommand('ter:update'));
-    $application->add(new Command\Extension\UploadExtensionVersionCommand('ter:publish'));
-    $application->add(new Command\Extension\VersionDetailsCommand('ter:version'));
+    $commands = [
+        new Command\Auth\CreateTokenCommand('ter:token:create'),
+        new Command\Auth\RefreshTokenCommand('ter:token:refresh'),
+        new Command\Auth\RevokeTokenCommand('ter:token:revoke'),
+        new Command\Extension\CreateExtensionArtefactCommand('create-artefact'),
+        new Command\Extension\DeleteExtensionCommand('ter:delete'),
+        new Command\Extension\ExtensionDetailsCommand('ter:details'),
+        new Command\Extension\ExtensionVersionsCommand('ter:versions'),
+        new Command\Extension\FindExtensionsCommand('ter:find'),
+        new Command\Extension\RegisterExtensionCommand('ter:register'),
+        new Command\Extension\SetExtensionVersionCommand('set-version'),
+        new Command\Extension\TransferExtensionCommand('ter:transfer'),
+        new Command\Extension\UpdateExtensionCommand('ter:update'),
+        new Command\Extension\UploadExtensionVersionCommand('ter:publish'),
+        new Command\Extension\VersionDetailsCommand('ter:version'),
+    ];
+    // Application::add() was replaced by addCommand() in symfony/console 7.4
+    // and removed in 8.0, while 6.4 only knows add()
+    $addMethod = method_exists($application, 'addCommand') ? 'addCommand' : 'add';
+    foreach ($commands as $command) {
+        $application->{$addMethod}($command);
+    }
     $application->run();
 });

--- a/bin/tailor
+++ b/bin/tailor
@@ -45,11 +45,6 @@ call_user_func(static function () {
         new Command\Extension\UploadExtensionVersionCommand('ter:publish'),
         new Command\Extension\VersionDetailsCommand('ter:version'),
     ];
-    // Application::add() was replaced by addCommand() in symfony/console 7.4
-    // and removed in 8.0, while 6.4 only knows add()
-    $addMethod = method_exists($application, 'addCommand') ? 'addCommand' : 'add';
-    foreach ($commands as $command) {
-        $application->{$addMethod}($command);
-    }
+    $application->addCommands($commands);
     $application->run();
 });

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.2",
         "ext-json": "*",
         "ext-zip": "*",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5",
-        "typo3/coding-standards": "^0.6.1 || dev-main"
+        "typo3/coding-standards": "^0.9"
     },
     "bin": [
         "bin/tailor"

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         "php": "^8.2",
         "ext-json": "*",
         "ext-zip": "*",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
-        "symfony/dotenv": "^5.4 || ^6.4 || ^7.0",
-        "symfony/http-client": "^5.4 || ^6.4 || ^7.0",
-        "symfony/mime": "^5.4 || ^6.4 || ^7.0"
+        "symfony/console": "^6.4 || ^7.4 || ^8.0",
+        "symfony/dotenv": "^6.4 || ^7.4 || ^8.0",
+        "symfony/http-client": "^6.4 || ^7.4 || ^8.0",
+        "symfony/mime": "^6.4 || ^7.4 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/mime": "^5.4 || ^6.4 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.36 || ^9.6.16",
+        "phpunit/phpunit": "^11.5",
         "typo3/coding-standards": "^0.6.1 || dev-main"
     },
     "bin": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./tests/bootstrap.php"
          cacheDirectory=".phpunit.cache">
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         bootstrap="./tests/bootstrap.php">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="./tests/bootstrap.php"
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>

--- a/src/HttpClientFactory.php
+++ b/src/HttpClientFactory.php
@@ -67,7 +67,7 @@ final class HttpClientFactory
         return HttpClient::create($options);
     }
 
-    protected static function getBaseUri(): string
+    private static function getBaseUri(): string
     {
         $remoteBaseUri = Variables::get('TYPO3_REMOTE_BASE_URI') ?: self::DEFAULT_BASE_URI;
         $apiVersion =  Variables::get('TYPO3_API_VERSION') ?: self::DEFAULT_API_VERSION;

--- a/tests/Unit/Environment/VariablesTest.php
+++ b/tests/Unit/Environment/VariablesTest.php
@@ -12,14 +12,13 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit\Environment;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\Tailor\Environment\Variables;
 
 class VariablesTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function hasVariableTest(): void
     {
         unset($_ENV);
@@ -43,9 +42,7 @@ class VariablesTest extends TestCase
         self::assertTrue(Variables::has('NOT_EMPTY_PUTENV', true));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getVariableTest(): void
     {
         unset($_ENV);

--- a/tests/Unit/Filesystem/ComposerReaderTest.php
+++ b/tests/Unit/Filesystem/ComposerReaderTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit\Filesystem;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\Tailor\Exception\InvalidComposerJsonException;
 use TYPO3\Tailor\Filesystem\ComposerReader;
@@ -33,9 +34,7 @@ class ComposerReaderTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throwsExceptionOnEmptyComposerJsonFile(): void
     {
         $this->expectExceptionCode(1610442954);
@@ -44,9 +43,7 @@ class ComposerReaderTest extends TestCase
         new ComposerReader('tmp');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throwsExceptionOnInvalidComposerJsonFile(): void
     {
         $this->expectExceptionCode(1610442954);
@@ -56,9 +53,7 @@ class ComposerReaderTest extends TestCase
         new ComposerReader('tmp');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function returnEmptyStringIfExtensionKeyNotGiven(): void
     {
         $composerContent = file_get_contents(__DIR__ . '/../Fixtures/Composer/composer_no_extension_key.json');
@@ -67,9 +62,7 @@ class ComposerReaderTest extends TestCase
         self::assertEmpty($subject->getExtensionKey());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function readCorrectExtensionKeyFromGivenComposerJsonFile(): void
     {
         $composerContent = file_get_contents(__DIR__ . '/../Fixtures/Composer/composer_with_extension_key.json');

--- a/tests/Unit/Filesystem/VersionReplacerTest.php
+++ b/tests/Unit/Filesystem/VersionReplacerTest.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit\Filesystem;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\Tailor\Filesystem\VersionReplacer;
 
 class VersionReplacerTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function replaceVersionReplacesProperVersionOfEmConf(): void
     {
         $emConfContents = file_get_contents(__DIR__ . '/../Fixtures/EmConf/emconf_valid.php');
@@ -41,10 +41,8 @@ class VersionReplacerTest extends TestCase
         yield 'Settings.cfg' => ['Settings.cfg', 'release\s*=\s*([0-9]+\.[0-9]+\.[0-9]+)', 'release=6.9.0'];
     }
 
-    /**
-     * @test
-     * @dataProvider replaceVersionReplacesProperReleaseOfDocumentationConfigurationDataProvider
-     */
+    #[Test]
+    #[DataProvider('replaceVersionReplacesProperReleaseOfDocumentationConfigurationDataProvider')]
     public function replaceVersionReplacesProperReleaseOfDocumentationConfiguration(
         string $docSettingsFile,
         string $docReleasePattern,
@@ -69,10 +67,8 @@ class VersionReplacerTest extends TestCase
         yield 'Settings.cfg' => ['Settings.cfg', 'version\s*=\s*([0-9]+\.[0-9]+)', 'version=6.9'];
     }
 
-    /**
-     * @test
-     * @dataProvider replaceVersionReplacesProperVersionOfDocumentationConfigurationDataProvider
-     */
+    #[Test]
+    #[DataProvider('replaceVersionReplacesProperVersionOfDocumentationConfigurationDataProvider')]
     public function replaceVersionReplacesProperVersionOfDocumentationConfiguration(
         string $docSettingsFile,
         string $docVersionPattern,
@@ -88,9 +84,7 @@ class VersionReplacerTest extends TestCase
         unlink($tempFile);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function replaceVersionThrowsExceptionOnInvalidFile(): void
     {
         $this->expectExceptionCode(1605741968);

--- a/tests/Unit/Formatter/ConsoleFormatterTest.php
+++ b/tests/Unit/Formatter/ConsoleFormatterTest.php
@@ -12,21 +12,16 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit\Formatter;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\Tailor\Formatter\ConsoleFormatter;
 use TYPO3\Tailor\Output\OutputPart;
 
 class ConsoleFormatterTest extends TestCase
 {
-    /**
-     * @test
-     * @dataProvider formatReturnsFormattedPartsDataProvider
-     *
-     * @param array $content
-     * @param array $expectedValues
-     * @param array $expectedOutputStyle
-     * @param int $formatType
-     */
+    #[Test]
+    #[DataProvider('formatReturnsFormattedPartsDataProvider')]
     public function formatReturnsFormattedParts(
         array $content,
         array $expectedValues,
@@ -48,7 +43,7 @@ class ConsoleFormatterTest extends TestCase
      *
      * @return \Generator
      */
-    public function formatReturnsFormattedPartsDataProvider(): \Generator
+    public static function formatReturnsFormattedPartsDataProvider(): \Generator
     {
         yield 'No output' => [
             [

--- a/tests/Unit/Helper/CommandHelperTest.php
+++ b/tests/Unit/Helper/CommandHelperTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit\Helper;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
@@ -37,9 +38,7 @@ final class CommandHelperTest extends TestCase
         $this->input = new ArrayInput([], $this->definition);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getExtensionKeyFromInputThrowsExceptionIfInputHasNoArgumentDefined(): void
     {
         $this->expectException(ExtensionKeyMissingException::class);
@@ -49,9 +48,7 @@ final class CommandHelperTest extends TestCase
         CommandHelper::getExtensionKeyFromInput($this->input);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getExtensionKeyFromInputReturnsExtensionKeyFromInputArgument(): void
     {
         $this->definition->addArgument(new InputArgument('extensionkey', InputArgument::REQUIRED));
@@ -60,9 +57,7 @@ final class CommandHelperTest extends TestCase
         self::assertSame('foo', CommandHelper::getExtensionKeyFromInput($this->input));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getExtensionKeyFromInputIgnoresEmptyInputArgumentValue(): void
     {
         $this->expectException(ExtensionKeyMissingException::class);
@@ -75,9 +70,7 @@ final class CommandHelperTest extends TestCase
         CommandHelper::getExtensionKeyFromInput($this->input);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getExtensionKeyFromInputReturnsExtensionKeyFromEnvironmentVariables(): void
     {
         putenv('TYPO3_EXTENSION_KEY=foo');

--- a/tests/Unit/HttpClientFactoryTest.php
+++ b/tests/Unit/HttpClientFactoryTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use TYPO3\Tailor\Dto\RequestConfiguration;
@@ -32,18 +33,14 @@ class HttpClientFactoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createHttpClientThrowsExceptionOnMissingCredentials(): void
     {
         $this->expectExceptionCode(1606995339);
         HttpClientFactory::create($this->requestConfiguration);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createHttpClientWithDefaultsTest(): void
     {
         unset($_ENV);
@@ -66,9 +63,7 @@ class HttpClientFactoryTest extends TestCase
         self::assertSame('data=some+value', $defaultOptions['body']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createHttpClientWithFallbackTest(): void
     {
         unset($_ENV);
@@ -82,9 +77,7 @@ class HttpClientFactoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createHttpClientWithOverrideTest(): void
     {
         unset($_ENV);
@@ -100,9 +93,7 @@ class HttpClientFactoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createHttpClientWithOverridePutenvTest(): void
     {
         unset($_ENV);
@@ -119,9 +110,7 @@ class HttpClientFactoryTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createHttpClientWithBearerAuthTest(): void
     {
         unset($_ENV);
@@ -134,9 +123,7 @@ class HttpClientFactoryTest extends TestCase
         self::assertSame('token123', $this->getDefaultOptions($httpClient)['auth_bearer']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createHttpClientWithBearerAuthOverrideTest(): void
     {
         unset($_ENV);
@@ -150,9 +137,7 @@ class HttpClientFactoryTest extends TestCase
         self::assertSame('token321', $this->getDefaultOptions($httpClient)['auth_bearer']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createHttpClientWithBasicAuthTest(): void
     {
         unset($_ENV);
@@ -166,9 +151,7 @@ class HttpClientFactoryTest extends TestCase
         self::assertSame('overridenUser:pass', $this->getDefaultOptions($httpClient)['auth_basic']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createHttpClientWithBasicAuthEnforcedTest(): void
     {
         unset($_ENV);
@@ -188,7 +171,6 @@ class HttpClientFactoryTest extends TestCase
     protected function getDefaultOptions(HttpClientInterface $httpClient): array
     {
         $defaultOptions = (new \ReflectionClass($httpClient))->getProperty('defaultOptions');
-        $defaultOptions->setAccessible(true);
 
         return $defaultOptions->getValue($httpClient);
     }

--- a/tests/Unit/Service/VersionServiceTest.php
+++ b/tests/Unit/Service/VersionServiceTest.php
@@ -12,15 +12,14 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit\Service;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\Tailor\Exception\RequiredConfigurationMissing;
 use TYPO3\Tailor\Service\VersionService;
 
 class VersionServiceTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function defaultExcludeFromPackagingConfigurationIsUsedOnNonExistingEnvVar(): void
     {
         unset($_ENV);
@@ -31,9 +30,7 @@ class VersionServiceTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function defaultExcludeFromPackagingConfigurationIsUsedOnEmptyPath(): void
     {
         unset($_ENV);
@@ -46,9 +43,7 @@ class VersionServiceTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function customExcludeFromPackagingConfigurationIsUsed(): void
     {
         unset($_ENV);
@@ -61,9 +56,7 @@ class VersionServiceTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throwsExceptionOnMissingCustomConfiguration(): void
     {
         unset($_ENV);
@@ -75,9 +68,7 @@ class VersionServiceTest extends TestCase
         new VersionService('1.0.0', 'my_ext', '/dummyPath');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throwsExceptionOnInvalidCustomConfiguration(): void
     {
         unset($_ENV);
@@ -89,9 +80,7 @@ class VersionServiceTest extends TestCase
         new VersionService('1.0.0', 'my_ext', '/dummyPath');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getVersionFilenameTest(): void
     {
         unset($_ENV);
@@ -103,9 +92,7 @@ class VersionServiceTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getVersionFilenameAsMd5Test(): void
     {
         unset($_ENV);
@@ -135,7 +122,6 @@ class VersionServiceTest extends TestCase
             ->getMock();
 
         $method = new \ReflectionMethod(VersionService::class, $methodName);
-        $method->setAccessible(true);
 
         return $method->invokeArgs($mock, $arguments);
     }

--- a/tests/Unit/Validation/EmConfVersionValidatorTest.php
+++ b/tests/Unit/Validation/EmConfVersionValidatorTest.php
@@ -12,15 +12,14 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit\Validation;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\Tailor\Validation\EmConfValidationError;
 use TYPO3\Tailor\Validation\EmConfVersionValidator;
 
 class EmConfVersionValidatorTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function collectErrorsReturnsErrorIfFileDoesNotExist(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/no-file');
@@ -28,9 +27,7 @@ class EmConfVersionValidatorTest extends TestCase
         self::assertSame($expected, $subject->collectErrors('1.2.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collectErrorsReturnsErrorIfConfigurationIsMissing(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_invalid.php');
@@ -38,9 +35,7 @@ class EmConfVersionValidatorTest extends TestCase
         self::assertSame($expected, $subject->collectErrors('1.0.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collectErrorsReturnsErrorIfFileDoesNotMatchEmConfStructure(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_no_structure.php');
@@ -48,9 +43,7 @@ class EmConfVersionValidatorTest extends TestCase
         self::assertSame($expected, $subject->collectErrors('1.0.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collectErrorsReturnsErrorsIfNoVersionGiven(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_no_version.php');
@@ -61,9 +54,7 @@ class EmConfVersionValidatorTest extends TestCase
         self::assertSame($expected, $subject->collectErrors('1.0.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collectErrorsReturnsErrorIfVersionsDoNotMatch(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_valid.php');
@@ -71,45 +62,35 @@ class EmConfVersionValidatorTest extends TestCase
         self::assertSame($expected, $subject->collectErrors('2.0.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function collectErrorsReturnsEmptyArrayIfFileIsValid(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_valid.php');
         self::assertSame([], $subject->collectErrors('1.0.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isInvalidIfNoFileFound(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/no-file');
         self::assertFalse($subject->isValid('1.2.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isInvalidIfFileDoesNotMatchEmConfStructure(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_invalid.php');
         self::assertFalse($subject->isValid('1.0.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isInvalidIfNoVersionGiven(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_no_version.php');
         self::assertFalse($subject->isValid('1.0.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isValidMatchesVersion(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_valid.php');
@@ -117,9 +98,7 @@ class EmConfVersionValidatorTest extends TestCase
         self::assertTrue($subject->isValid('1.0.0'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isValidWithStringArrayKey(): void
     {
         $subject = new EmConfVersionValidator(__DIR__ . '/../Fixtures/EmConf/emconf_valid_string_array_key.php');

--- a/tests/Unit/Validation/VersionValidatorTest.php
+++ b/tests/Unit/Validation/VersionValidatorTest.php
@@ -12,18 +12,15 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit\Validation;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\Tailor\Validation\VersionValidator;
 
 class VersionValidatorTest extends TestCase
 {
-    /**
-     * @test
-     * @dataProvider isValidTestDataProvider
-     *
-     * @param string $input
-     * @param bool $expected
-     */
+    #[Test]
+    #[DataProvider('isValidTestDataProvider')]
     public function isValidTest(string $input, bool $expected): void
     {
         self::assertEquals($expected, (new VersionValidator())->isValid($input));
@@ -34,7 +31,7 @@ class VersionValidatorTest extends TestCase
      *
      * @return \Generator
      */
-    public function isValidTestDataProvider(): \Generator
+    public static function isValidTestDataProvider(): \Generator
     {
         yield 'Wrong format' => [
             'v1',


### PR DESCRIPTION
This pull request updates the project to require PHP 8.2 or higher and modernizes dependencies and test code. The main changes include raising the minimum PHP version, updating Symfony and PHPUnit dependencies, and refactoring test annotations to use PHP attributes.

**Dependency and environment updates:**

* Increased the minimum required PHP version to 8.2 in `composer.json`, and updated the supported Symfony package versions to `^6.4 || ^7.4 || ^8.0` (`composer.json`).
* Updated the PHPUnit dependency to `^11.5` and the coding standards package to `^0.9` in `composer.json`.
* The GitHub Actions workflow in `.github/workflows/tests.yml` now only tests against PHP 8.2 and above, dropping support for older PHP versions.
* Updated the PHP version in the `README.md` CI example to 8.2.
* Updated `phpunit.xml.dist` to use the PHPUnit 11.5 schema and added a cache directory.

**Test modernization:**

* Refactored all test classes to use PHP 8+ attributes (`#[Test]`, `#[DataProvider]`) instead of docblock annotations for test methods and data providers [[1]](diffhunk://#diff-0614b776b26bd20675abd0daacc27285cae3ba89a36d3e00c290804d8571d850R15-R21) [[2]](diffhunk://#diff-0614b776b26bd20675abd0daacc27285cae3ba89a36d3e00c290804d8571d850L46-R45) [[3]](diffhunk://#diff-62d330abdd91d96779d44d6025a31faef1bdc95d0fca483aedbdb7edf09d5376R15) [[4]](diffhunk://#diff-62d330abdd91d96779d44d6025a31faef1bdc95d0fca483aedbdb7edf09d5376L36-R37) [[5]](diffhunk://#diff-62d330abdd91d96779d44d6025a31faef1bdc95d0fca483aedbdb7edf09d5376L47-R46) [[6]](diffhunk://#diff-62d330abdd91d96779d44d6025a31faef1bdc95d0fca483aedbdb7edf09d5376L59-R56) [[7]](diffhunk://#diff-62d330abdd91d96779d44d6025a31faef1bdc95d0fca483aedbdb7edf09d5376L70-R65) [[8]](diffhunk://#diff-ff8ea6b6f6f7e8b24d13a115fec35109b2fa46e3603acdaca36fc00f93971d53R15-R22) [[9]](diffhunk://#diff-ff8ea6b6f6f7e8b24d13a115fec35109b2fa46e3603acdaca36fc00f93971d53L44-R45) [[10]](diffhunk://#diff-ff8ea6b6f6f7e8b24d13a115fec35109b2fa46e3603acdaca36fc00f93971d53L72-R71) [[11]](diffhunk://#diff-ff8ea6b6f6f7e8b24d13a115fec35109b2fa46e3603acdaca36fc00f93971d53L91-R87) [[12]](diffhunk://#diff-bda3586aed25ba830756373d4169ff40bab33ac0336bf81fa652c7aaf27b25f5R15-R24) [[13]](diffhunk://#diff-bda3586aed25ba830756373d4169ff40bab33ac0336bf81fa652c7aaf27b25f5L51-R46) [[14]](diffhunk://#diff-bc959a0e0c7aa8f2a9d7db819db79e0c9977f2aa09b96ab7785346b4f1042e9aR15) [[15]](diffhunk://#diff-bc959a0e0c7aa8f2a9d7db819db79e0c9977f2aa09b96ab7785346b4f1042e9aL40-R41) [[16]](diffhunk://#diff-bc959a0e0c7aa8f2a9d7db819db79e0c9977f2aa09b96ab7785346b4f1042e9aL52-R51) [[17]](diffhunk://#diff-bc959a0e0c7aa8f2a9d7db819db79e0c9977f2aa09b96ab7785346b4f1042e9aL63-R60) [[18]](diffhunk://#diff-bc959a0e0c7aa8f2a9d7db819db79e0c9977f2aa09b96ab7785346b4f1042e9aL78-R73) [[19]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7R15) [[20]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L35-R43) [[21]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L69-R66) [[22]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L85-R80) [[23]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L103-R96) [[24]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L122-R113) [[25]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L137-R126) [[26]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L153-R140) [[27]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L169-R154) [[28]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L191) [[29]](diffhunk://#diff-0ae21bb852998b24fb5aabf0b32cbe859309642c0b3059b031f9298344013a1cR15-R22).

**Code quality and compatibility:**

* Changed the visibility of `getBaseUri()` in `HttpClientFactory` from `protected` to `private` to better encapsulate the method.
* Made minor improvements to test utility methods, such as making the data provider static [[1]](diffhunk://#diff-bda3586aed25ba830756373d4169ff40bab33ac0336bf81fa652c7aaf27b25f5L51-R46) and removing deprecated code [[2]](diffhunk://#diff-066b66380075c169d91ff229165da70907f4a2f495eefdfd29efe3a817ed08f7L191).

These changes ensure the codebase is compatible with modern PHP and Symfony versions, improves test reliability and readability, and removes support for legacy PHP versions.