### PR TITLE
[FEATURE] Warn about tags TER already implies

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,19 @@ To update the tags:
 ./vendor/bin/tailor ter:update my_extension --tags=some-tag,another-tag
 ```
 
+Tags are what people search the extension listing by, so they are worth
+choosing for TER specifically. Every extension in TER is a TYPO3 extension,
+which means terms such as `typo3`, `typo3-extension`, `extension`, `cms` or
+`php` narrow nothing down there — even though the very same terms are what
+make a package findable on GitHub or Packagist. Prefer tags describing what
+the extension does. Tailor warns when it recognises such a term, but still
+sends whatever you pass.
+
+This matters most for automated publishing: because the whole list is
+replaced on every call (see below), a pipeline that reuses one vocabulary
+across registries will keep overwriting curated TER tags with terms that add
+nothing.
+
 Please use `./vendor/bin/tailor ter:update -h` to see the full
 list of available options.
 

--- a/src/Command/Extension/UpdateExtensionCommand.php
+++ b/src/Command/Extension/UpdateExtensionCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\Tailor\Command\AbstractClientRequestCommand;
 use TYPO3\Tailor\Dto\Messages;
 use TYPO3\Tailor\Dto\RequestConfiguration;
@@ -57,7 +58,34 @@ class UpdateExtensionCommand extends AbstractClientRequestCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->extensionKey = CommandHelper::getExtensionKeyFromInput($input);
+        $this->warnAboutTagsImpliedByTer($input, $output);
+
         return parent::execute($input, $output);
+    }
+
+    /**
+     * TER replaces the whole tag list with what is sent, so a pipeline reusing
+     * one vocabulary across registries silently publishes terms that say
+     * nothing here. Point them out without changing what gets sent.
+     */
+    private function warnAboutTagsImpliedByTer(InputInterface $input, OutputInterface $output): void
+    {
+        $tags = $input->getOption('tags');
+        if (!is_string($tags) || $tags === '') {
+            return;
+        }
+
+        $implied = CommandHelper::getTagsImpliedByTer($tags);
+        if ($implied === []) {
+            return;
+        }
+
+        (new SymfonyStyle($input, $output))->warning(sprintf(
+            'Every extension in TER is a TYPO3 extension, so %s %s no discoverability there. '
+            . 'Consider tags describing what the extension does instead.',
+            implode(', ', $implied),
+            count($implied) === 1 ? 'adds' : 'add'
+        ));
     }
 
     protected function getRequestConfiguration(): RequestConfiguration

--- a/src/Command/Extension/UpdateExtensionCommand.php
+++ b/src/Command/Extension/UpdateExtensionCommand.php
@@ -52,7 +52,14 @@ class UpdateExtensionCommand extends AbstractClientRequestCommand
             ->addOption('repository', '', InputOption::VALUE_OPTIONAL, 'Link to the repository')
             ->addOption('manual', '', InputOption::VALUE_OPTIONAL, 'Link to the external manual')
             ->addOption('paypal', '', InputOption::VALUE_OPTIONAL, 'Link to sponsoring page (paypal)')
-            ->addOption('tags', '', InputOption::VALUE_OPTIONAL, 'Comma-separated list of tags');
+            ->addOption(
+                'tags',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                'Comma-separated list of tags. Replaces the existing list. Every extension in TER is a '
+                . 'TYPO3 extension, so terms like typo3, typo3-extension, extension or php add no '
+                . 'discoverability there - prefer tags describing what the extension does.'
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Helper/CommandHelper.php
+++ b/src/Helper/CommandHelper.php
@@ -23,24 +23,30 @@ use TYPO3\Tailor\Filesystem\ComposerReader;
 final class CommandHelper
 {
     /**
-     * Tags that every TER listing already implies. TER only lists TYPO3
-     * extensions, so these narrow nothing down there — unlike on GitHub or
-     * Packagist, where the same terms are what make a package findable at all.
+     * Terms every TER listing already implies. TER only lists TYPO3 extensions,
+     * so these narrow nothing down there — unlike on GitHub or Packagist, where
+     * the same terms are what make a package findable at all.
+     *
+     * Compared after stripping separators, so the spelling variants that occur
+     * in practice — "typo3 cms" in composer.json keywords, "typo3-cms-extension"
+     * in GitHub topics — are all recognised.
      *
      * @var string[]
      */
     private const TAGS_IMPLIED_BY_TER = [
         'cms',
+        'cmsextension',
         'extension',
         'extensions',
         'php',
         'ter',
         'typo3',
-        'typo3-cms',
-        'typo3-extension',
         'typo3cms',
+        'typo3cmsextension',
         'typo3ext',
+        'typo3extension',
     ];
+
     public static function getExtensionKeyFromInput(InputInterface $input): string
     {
         // 1. CLI argument has highest priority
@@ -74,7 +80,7 @@ final class CommandHelper
 
     /**
      * Returns those of the given tags that TER already implies, so the caller
-     * can point them out. Comparison is case-insensitive.
+     * can point them out. Case and separators are ignored.
      *
      * @return string[]
      */
@@ -84,7 +90,12 @@ final class CommandHelper
 
         foreach (explode(',', $tags) as $tag) {
             $tag = trim($tag);
-            if ($tag !== '' && in_array(strtolower($tag), self::TAGS_IMPLIED_BY_TER, true)) {
+            if ($tag === '') {
+                continue;
+            }
+
+            $normalized = strtolower((string)preg_replace('/[^a-z0-9]/i', '', $tag));
+            if (in_array($normalized, self::TAGS_IMPLIED_BY_TER, true)) {
                 $implied[] = $tag;
             }
         }

--- a/src/Helper/CommandHelper.php
+++ b/src/Helper/CommandHelper.php
@@ -22,6 +22,25 @@ use TYPO3\Tailor\Filesystem\ComposerReader;
  */
 final class CommandHelper
 {
+    /**
+     * Tags that every TER listing already implies. TER only lists TYPO3
+     * extensions, so these narrow nothing down there — unlike on GitHub or
+     * Packagist, where the same terms are what make a package findable at all.
+     *
+     * @var string[]
+     */
+    private const TAGS_IMPLIED_BY_TER = [
+        'cms',
+        'extension',
+        'extensions',
+        'php',
+        'ter',
+        'typo3',
+        'typo3-cms',
+        'typo3-extension',
+        'typo3cms',
+        'typo3ext',
+    ];
     public static function getExtensionKeyFromInput(InputInterface $input): string
     {
         // 1. CLI argument has highest priority
@@ -51,5 +70,25 @@ final class CommandHelper
             'The extension key must either be set as argument or in composer.json at [extra][typo3/cms][extension-key].',
             1605706548
         );
+    }
+
+    /**
+     * Returns those of the given tags that TER already implies, so the caller
+     * can point them out. Comparison is case-insensitive.
+     *
+     * @return string[]
+     */
+    public static function getTagsImpliedByTer(string $tags): array
+    {
+        $implied = [];
+
+        foreach (explode(',', $tags) as $tag) {
+            $tag = trim($tag);
+            if ($tag !== '' && in_array(strtolower($tag), self::TAGS_IMPLIED_BY_TER, true)) {
+                $implied[] = $tag;
+            }
+        }
+
+        return $implied;
     }
 }

--- a/tests/Unit/Helper/CommandHelperTest.php
+++ b/tests/Unit/Helper/CommandHelperTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace TYPO3\Tailor\Tests\Unit\Helper;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -97,5 +98,32 @@ final class CommandHelperTest extends TestCase
         } finally {
             restore_error_handler();
         }
+    }
+
+    /**
+     * @param string[] $expected
+     */
+    #[Test]
+    #[DataProvider('tagsImpliedByTerDataProvider')]
+    public function getTagsImpliedByTerReturnsOnlyTermsTerAlreadyImplies(string $tags, array $expected): void
+    {
+        self::assertSame($expected, CommandHelper::getTagsImpliedByTer($tags));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string[]}>
+     */
+    public static function tagsImpliedByTerDataProvider(): array
+    {
+        return [
+            'empty input' => ['', []],
+            'only domain tags' => ['search,indexing,facets', []],
+            'single implied tag' => ['typo3,search', ['typo3']],
+            'several implied tags' => ['typo3,php,search,extension', ['typo3', 'php', 'extension']],
+            'case is ignored' => ['TYPO3,Extension', ['TYPO3', 'Extension']],
+            'surrounding whitespace' => [' typo3 , search ', ['typo3']],
+            'empty segments' => ['typo3,,search,', ['typo3']],
+            'substring is not a match' => ['typo3-solr,phpunit', []],
+        ];
     }
 }

--- a/tests/Unit/Helper/CommandHelperTest.php
+++ b/tests/Unit/Helper/CommandHelperTest.php
@@ -124,6 +124,17 @@ final class CommandHelperTest extends TestCase
             'surrounding whitespace' => [' typo3 , search ', ['typo3']],
             'empty segments' => ['typo3,,search,', ['typo3']],
             'substring is not a match' => ['typo3-solr,phpunit', []],
+            // Spelling variants observed in the wild: composer.json keywords
+            // favour "typo3 cms", GitHub topics "typo3-cms-extension".
+            'separator variants' => [
+                'typo3 cms,typo3-cms,typo3cms',
+                ['typo3 cms', 'typo3-cms', 'typo3cms'],
+            ],
+            'extension variants' => [
+                'typo3-cms-extension,typo3-extension,cms-extension',
+                ['typo3-cms-extension', 'typo3-extension', 'cms-extension'],
+            ],
+            'domain tag with separator survives' => ['e-commerce,tt_news', []],
         ];
     }
 }


### PR DESCRIPTION
Resolves #96, along the lines @bmack agreed to there: warning plus README update.

## The rule

Every extension in TER is a TYPO3 extension, so `typo3`, `typo3-extension`, `extension`, `cms` and `php` narrow nothing down there. The same terms are what make a package findable on GitHub or Packagist — which is exactly why a publishing pipeline that reuses one vocabulary across registries sends them to TER.

## Measured, not assumed

I first wrote the term list from that reasoning alone. Checking it against 3000 TER extensions and the three vocabularies of the top 60 by downloads changed it:

| Vocabulary | Platform terms | Share |
| --- | --- | --- |
| TER tags (625 occurrences) | 5 | 0.8% |
| composer.json keywords (207) | 46 | **22%** |
| GitHub topics (92) | ~50 | **54%** |

Two things follow. TER tags are largely clean today — the top terms are `content`, `backend`, `responsive`, `news`, `typoscript` — so this is preventive rather than a fix for a widespread mess. And the sources a pipeline would copy from are anything but clean, so the warning earns its place the moment tags are automated.

The measurement also corrected the list: composer.json keywords favour **`typo3 cms` with a space** (the second most common keyword overall) and GitHub topics favour **`typo3-cms-extension`** — neither was in my first draft. Rather than enumerate permutations, terms are now compared with separators stripped, so those variants and future ones collapse to one entry. Domain tags that legitimately contain separators (`e-commerce`, `tt_news`) are unaffected, and a test pins that down.

Worth noting alongside: only 134 of 3000 sampled extensions use tags at all.

## Warning, not filter

```
 [WARNING] Every extension in TER is a TYPO3 extension, so typo3, php add no
           discoverability there. Consider tags describing what the extension
           does instead.
```

The request goes out unchanged. Tailor is a thin client over `PUT /extension/{key}`; dropping a value someone passed explicitly would be surprising, and which terms count as too generic is a judgement for the caller.

## Discoverable before the run, not only after

A runtime warning arrives once a pipeline has been written and executed. The rule is therefore also in the `--tags` description, which is what `ter:update -h` prints and what someone — or a coding agent — reads while writing that pipeline:

```
--tags[=TAGS]   Comma-separated list of tags. Replaces the existing list. Every
                extension in TER is a TYPO3 extension, so terms like typo3,
                typo3-extension, extension or php add no discoverability there -
                prefer tags describing what the extension does.
```

The README section gains the same reasoning and connects it to the replace semantics documented just below it — that combination is what bites automated publishing, since every release overwrites curated tags.

## Implementation

Matching lives in `CommandHelper::getTagsImpliedByTer()` so it is unit-tested rather than buried in the command: case-insensitive, separator-insensitive, tolerant of whitespace and empty segments, and no substring matches.

`composer cs` clean, `composer tests:unit` green — 67 tests, 183 assertions, 11 of them new.